### PR TITLE
[FYI] Pulse schedule performance improve

### DIFF
--- a/qiskit/pulse/commands/instruction.py
+++ b/qiskit/pulse/commands/instruction.py
@@ -18,10 +18,11 @@ Instruction = Leaf node of schedule.
 from typing import Tuple, List, Iterable, Callable, Optional
 
 from qiskit.pulse.channels import Channel
+from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.interfaces import ScheduleComponent
 from qiskit.pulse.schedule import Schedule
 from qiskit.pulse.timeslots import Interval, Timeslot, TimeslotCollection
-from qiskit.pulse.exceptions import PulseError
+
 
 # pylint: disable=missing-return-doc,missing-type-doc
 
@@ -74,7 +75,7 @@ class Instruction(ScheduleComponent):
         return self._command
 
     @property
-    def channels(self) -> Tuple[Channel]:
+    def channels(self) -> Tuple[Channel, ...]:
         """Returns channels that this schedule uses."""
         return self.timeslots.channels
 
@@ -104,16 +105,16 @@ class Instruction(ScheduleComponent):
         return self._buffer
 
     @property
-    def _children(self) -> Tuple[ScheduleComponent]:
+    def _children(self) -> Tuple[ScheduleComponent, ...]:
         """Instruction has no child nodes."""
         return ()
 
     @property
-    def instructions(self) -> Tuple[Tuple[int, 'Instruction']]:
+    def instructions(self) -> Tuple[Tuple[int, 'Instruction'], ...]:
         """Iterable for getting instructions from Schedule tree."""
         return tuple(self._instructions())
 
-    def ch_duration(self, *channels: List[Channel]) -> int:
+    def ch_duration(self, *channels: Channel) -> int:
         """Return duration of the supplied channels in this Instruction.
 
         Args:
@@ -121,7 +122,7 @@ class Instruction(ScheduleComponent):
         """
         return self.timeslots.ch_duration(*channels)
 
-    def ch_start_time(self, *channels: List[Channel]) -> int:
+    def ch_start_time(self, *channels: Channel) -> int:
         """Return minimum start time for supplied channels.
 
         Args:
@@ -129,7 +130,7 @@ class Instruction(ScheduleComponent):
         """
         return self.timeslots.ch_start_time(*channels)
 
-    def ch_stop_time(self, *channels: List[Channel]) -> int:
+    def ch_stop_time(self, *channels: Channel) -> int:
         """Return maximum start time for supplied channels.
 
         Args:
@@ -153,7 +154,7 @@ class Instruction(ScheduleComponent):
         """Return itself as already single instruction."""
         return self
 
-    def union(self, *schedules: List[ScheduleComponent], name: Optional[str] = None) -> 'Schedule':
+    def union(self, *schedules: ScheduleComponent, name: Optional[str] = None) -> 'Schedule':
         """Return a new schedule which is the union of `self` and `schedule`.
 
         Args:

--- a/qiskit/pulse/interfaces.py
+++ b/qiskit/pulse/interfaces.py
@@ -16,11 +16,12 @@
 ScheduleComponent, a common interface for components of schedule (Instruction and Schedule).
 """
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, List, Union, Optional
+from typing import Tuple, Union, Optional
 
 from qiskit.pulse.channels import Channel
 
 from .timeslots import TimeslotCollection
+
 
 # pylint: disable=missing-type-doc
 
@@ -36,7 +37,7 @@ class ScheduleComponent(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def channels(self) -> List[Channel]:
+    def channels(self) -> Tuple[Channel, ...]:
         """Return channels used by schedule."""
         pass
 
@@ -64,17 +65,17 @@ class ScheduleComponent(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def ch_duration(self, *channels: List[Channel]) -> int:
+    def ch_duration(self, *channels: Channel) -> int:
         """Duration of the `channels` in schedule component."""
         pass
 
     @abstractmethod
-    def ch_start_time(self, *channels: List[Channel]) -> int:
+    def ch_start_time(self, *channels: Channel) -> int:
         """Starting time of the `channels` in schedule component. """
         pass
 
     @abstractmethod
-    def ch_stop_time(self, *channels: List[Channel]) -> int:
+    def ch_stop_time(self, *channels: Channel) -> int:
         """Stopping of the `channels` in schedule component."""
         pass
 
@@ -86,13 +87,13 @@ class ScheduleComponent(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def _children(self) -> Tuple[Union[int, 'ScheduleComponent']]:
+    def _children(self) -> Tuple[Union[int, 'ScheduleComponent'], ...]:
         """Child nodes of this schedule component. """
         pass
 
     @property
     @abstractmethod
-    def instructions(self) -> Tuple[Tuple[int, 'Instructions']]:
+    def instructions(self) -> Tuple[Tuple[int, 'Instructions'], ...]:
         """Return iterable for all `Instruction`s in `Schedule` tree."""
         pass
 
@@ -102,7 +103,7 @@ class ScheduleComponent(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def union(self, *schedules: List['ScheduleComponent'],
+    def union(self, *schedules: 'ScheduleComponent',
               name: Optional[str] = None) -> 'ScheduleComponent':
         """Return a new schedule which is the union of the parent `Schedule` and `schedule`.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Address #2817. This PR improves the run time of the sample code given in #2817 from 34s (273s) to 0.4s (5.5s) by removing unnecessary time slot overlap check.

### Details and comments
- Deligate overlap check in `TimeslotCollection.merged()` to `is_mergable_with()`
- Introduce option not to check overlap in `insert`, `union`, `__init__` of `Schedule`

