### PR TITLE
Add support for delay gate

### DIFF
--- a/qiskit/compiler/schedule.py
+++ b/qiskit/compiler/schedule.py
@@ -39,6 +39,7 @@ def schedule(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
              backend: Optional[BaseBackend] = None,
              inst_map: Optional[InstructionScheduleMap] = None,
              meas_map: Optional[List[List[int]]] = None,
+             dt: Optional[float] = None,
              method: Optional[Union[str, List[str]]] = None) -> Union[Schedule, List[Schedule]]:
     """
     Schedule a circuit to a pulse ``Schedule``, using the backend, according to any specified
@@ -51,6 +52,8 @@ def schedule(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
                   ``backend``\'s ``instruction_schedule_map``
         meas_map: List of sets of qubits that must be measured together. If ``None``, defaults to
                   the ``backend``\'s ``meas_map``
+        dt: For scheduled circuits which contain time information, dt is required. If not provided,
+            it will be obtained from the backend configuration
         method: Optionally specify a particular scheduling method
 
     Returns:
@@ -69,8 +72,11 @@ def schedule(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
         if backend is None:
             raise QiskitError("Must supply either a backend or a meas_map for scheduling passes.")
         meas_map = backend.configuration().meas_map
+    if dt is None:
+        if backend is not None:
+            dt = backend.configuration().dt
 
-    schedule_config = ScheduleConfig(inst_map=inst_map, meas_map=meas_map)
+    schedule_config = ScheduleConfig(inst_map=inst_map, meas_map=meas_map, dt=dt)
     circuits = circuits if isinstance(circuits, list) else [circuits]
     schedules = [schedule_circuit(circuit, schedule_config, method) for circuit in circuits]
     end_time = time()

--- a/qiskit/compiler/sequence.py
+++ b/qiskit/compiler/sequence.py
@@ -27,8 +27,7 @@ from qiskit.compiler.schedule import schedule
 def sequence(scheduled_circuits: Union[QuantumCircuit, List[QuantumCircuit]],
              backend: Optional[BaseBackend] = None,
              inst_map: Optional[InstructionScheduleMap] = None,
-             meas_map: Optional[List[List[int]]] = None,
-             dt: Optional[float] = None) -> Union[Schedule, List[Schedule]]:
+             meas_map: Optional[List[List[int]]] = None) -> Union[Schedule, List[Schedule]]:
     """
     Schedule a scheduled circuit to a pulse ``Schedule``, using the backend.
 
@@ -45,4 +44,5 @@ def sequence(scheduled_circuits: Union[QuantumCircuit, List[QuantumCircuit]],
     Returns:
         A pulse ``Schedule`` that implements the input circuit
     """
-    return schedule(scheduled_circuits, backend, inst_map, meas_map, 'sequence')
+    return schedule(scheduled_circuits, backend=backend, inst_map=inst_map,
+                    meas_map=meas_map, method='sequence', dt=1)

--- a/qiskit/compiler/sequence.py
+++ b/qiskit/compiler/sequence.py
@@ -34,7 +34,8 @@ LOG = logging.getLogger(__name__)
 def sequence(scheduled_circuits: Union[QuantumCircuit, List[QuantumCircuit]],
              backend: Optional[BaseBackend] = None,
              inst_map: Optional[InstructionScheduleMap] = None,
-             meas_map: Optional[List[List[int]]] = None) -> Union[Schedule, List[Schedule]]:
+             meas_map: Optional[List[List[int]]] = None,
+             dt: Optional[float] = None) -> Union[Schedule, List[Schedule]]:
     """
     Schedule a scheduled circuit to a pulse ``Schedule``, using the backend.
 
@@ -45,6 +46,8 @@ def sequence(scheduled_circuits: Union[QuantumCircuit, List[QuantumCircuit]],
                   ``backend``\'s ``instruction_schedule_map``
         meas_map: List of sets of qubits that must be measured together. If ``None``, defaults to
                   the ``backend``\'s ``meas_map``
+        dt: For scheduled circuits which contain time information, dt is required. If not provided,
+            it will be obtained from the backend configuration
 
     Returns:
         A pulse ``Schedule`` that implements the input circuit
@@ -61,8 +64,12 @@ def sequence(scheduled_circuits: Union[QuantumCircuit, List[QuantumCircuit]],
         if backend is None:
             raise QiskitError("Must supply either a backend or a meas_map for scheduling passes.")
         meas_map = backend.configuration().meas_map
+    if dt is None:
+        if backend is None:
+            raise QiskitError("Must supply either a backend or the value of dt.")
+        dt = backend.configuration().dt
 
-    schedule_config = ScheduleConfig(inst_map=inst_map, meas_map=meas_map)
+    schedule_config = ScheduleConfig(inst_map=inst_map, meas_map=meas_map, dt=dt)
     circuits = scheduled_circuits if isinstance(scheduled_circuits, list) else [scheduled_circuits]
     schedules = [_sequence(circuit, schedule_config) for circuit in circuits]
     return schedules[0] if len(schedules) == 1 else schedules

--- a/qiskit/scheduler/config.py
+++ b/qiskit/scheduler/config.py
@@ -26,13 +26,16 @@ class ScheduleConfig():
 
     def __init__(self,
                  inst_map: InstructionScheduleMap,
-                 meas_map: List[List[int]]):
+                 meas_map: List[List[int]],
+                 dt: float):
         """
         Container for information needed to schedule a QuantumCircuit into a pulse Schedule.
 
         Args:
             inst_map: The schedule definition of all gates supported on a backend.
             meas_map: A list of groups of qubits which have to be measured together.
+            dt: Sample duration.
         """
         self.inst_map = inst_map
         self.meas_map = format_meas_map(meas_map)
+        self.dt = dt

--- a/qiskit/scheduler/methods/lowering.py
+++ b/qiskit/scheduler/methods/lowering.py
@@ -58,6 +58,7 @@ def lower_gates(circuit: QuantumCircuit, schedule_config: ScheduleConfig) -> Lis
         QiskitError: If circuit uses a command that isn't defined in config.inst_map.
     """
     circ_pulse_defs = []
+    circ_pulse_defs = []
 
     inst_map = schedule_config.inst_map
     qubit_mem_slots = {}  # Map measured qubit index to classical bit index
@@ -79,20 +80,29 @@ def lower_gates(circuit: QuantumCircuit, schedule_config: ScheduleConfig) -> Lis
         if any(q in qubit_mem_slots for q in inst_qubits):
             # If we are operating on a qubit that was scheduled to be measured, process that first
             circ_pulse_defs.append(get_measure_schedule())
+
         if isinstance(inst, Barrier):
             circ_pulse_defs.append(CircuitPulseDef(schedule=inst, qubits=inst_qubits))
+
         elif isinstance(inst, Delay):
-            sched = Schedule(name=inst.name)
-            for q in inst_qubits:
-                sched += pulse_inst.Delay(duration=inst.duration, channel=DriveChannel(q))  # OK?
-                sched += pulse_inst.Delay(duration=inst.duration, channel=MeasureChannel(q))  # OK?
+            if inst.unit == 'dt':
+                duration = inst.duration
+            else:
+                duration_s = _convert_to_seconds(inst.duration, inst.unit)
+                duration = int(duration_s // schedule_config.dt)
+            schedule = Schedule(name=inst.name)
+            for qubit in inst_qubits:
+                for chan in [pulse.DriveChannel, pulse.AcquireChannel, pulse.MeasureChannel]:
+                    schedule += pulse_inst.Delay(duration=duration, channel=channel(qubit))
             circ_pulse_defs.append(CircuitPulseDef(schedule=sched, qubits=inst_qubits))
+
         elif isinstance(inst, Measure):
             if (len(inst_qubits) != 1 and len(clbits) != 1):
                 raise QiskitError("Qubit '{0}' or classical bit '{1}' errored because the "
                                   "circuit Measure instruction only takes one of "
                                   "each.".format(inst_qubits, clbits))
             qubit_mem_slots[inst_qubits[0]] = clbits[0].index
+
         else:
             try:
                 circ_pulse_defs.append(
@@ -106,3 +116,14 @@ def lower_gates(circuit: QuantumCircuit, schedule_config: ScheduleConfig) -> Lis
         circ_pulse_defs.append(get_measure_schedule())
 
     return circ_pulse_defs
+
+def _convert_to_seconds(value: float, unit: str) -> float:
+    """Convert input value to seconds by applying unit to value."""
+    prefixes = {'p': 1e-12, 'n': 1e-9, 'u': 1e-6, 'µ': 1e-6,
+                'm': 1e-3, 'k': 1e3, 'M': 1e6, 'G': 1e9, 's': 1}
+    if not unit:
+        return value
+    try:
+        return value * prefixes[unit[0]]
+    except KeyError:
+        raise QiskitError("Error parsing delay operation duration.")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Needed to be updated to handle all possible units of Delay instruction duration, including dt, which requires knowing dt.

Aquire, Measure, and Drive channels should all get pulse.Delays in the output schedule.

### Details and comments


