### PR TITLE
Add UDD to Transpiler

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -139,7 +139,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             E.g. [('cx', [0, 1], 1000), ('u3', [0], 300)]
             Durations defined in ``backend.properties`` are used as default and
             they are overwritten with the instruction_durations.
-        dynamical_decoupling: The name of the dynamical decoupling seqeuence to insert into times 
+        dynamical_decoupling: The name of the dynamical decoupling sequence to insert into times 
             when the qubit(s) is/are idling for durations longer than the duration of the specified
             DD sequence. The circuit will need to be converted to a scheduled circuit before DD 
             sequences can be inserted. If no scheduling method is provided, 'alap' will be provided 

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -375,8 +375,10 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
             pass_manager.append(ALAPSchedule(pass_manager_config.instruction_durations))
         if dynamical_decoupling[:3] in {'udd', 'UDD'}:
             try:
-                N = int(dynamical_decoupling[4:]) 
+                N = int(dynamical_decoupling[4:])
                 from qiskit.transpiler.passes import UDDPass
+                if N < 2:
+                    raise TranspilerError("UDD must have order of at least 2.")
                 backend_properties = pass_manager_config.backend_properties
                 dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
                 pass_manager.append(UDDPass(N, backend_properties, dt_in_sec))

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -52,6 +52,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
               translation_method: Optional[str] = None,
               scheduling_method: Optional[str] = None,
               instruction_durations: Optional[InstructionDurationsType] = None,
+              dynamical_decoupling: Optional[str] = None,
               seed_transpiler: Optional[int] = None,
               optimization_level: Optional[int] = None,
               pass_manager: Optional[PassManager] = None,
@@ -138,6 +139,11 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             E.g. [('cx', [0, 1], 1000), ('u3', [0], 300)]
             Durations defined in ``backend.properties`` are used as default and
             they are overwritten with the instruction_durations.
+        dynamical_decoupling: The name of the dynamical decoupling seqeuence to insert into times 
+            when the qubit(s) is/are idling for durations longer than the duration of the specified
+            DD seqeuence. The circuit will need to be converted to a schedule before DD sequences 
+            can be inserted. If no scheduling method is provided, 'alap' will be provided 
+            automatically as the scheduling method.
         seed_transpiler: Sets random seed for the stochastic parts of the transpiler
         optimization_level: How much optimization to perform on the circuits.
             Higher levels generate more optimized circuits,
@@ -232,8 +238,8 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
                                            backend_properties, initial_layout,
                                            layout_method, routing_method, translation_method,
                                            scheduling_method, instruction_durations,
-                                           seed_transpiler, optimization_level,
-                                           callback, output_name)
+                                           dynamical_decoupling, seed_transpiler,
+                                           optimization_level, callback, output_name)
 
     _check_circuits_coupling_map(circuits, transpile_args, backend)
 
@@ -348,7 +354,7 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
         pass_manager = level_2_pass_manager(pass_manager_config)
     elif level == 3:
         pass_manager = level_3_pass_manager(pass_manager_config)
-    else:
+    else: 
         raise TranspilerError("optimization_level can range from 0 to 3.")
 
     if ms_basis_swap is not None:
@@ -361,6 +367,24 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
         from qiskit.transpiler.passes.scheduling import RemoveOpsOnIdleQubits
         pass_manager.append(RemoveOpsOnIdleQubits())
 
+    dynamical_decoupling = pass_manager_config.dynamical_decoupling
+    backend_properties = pass_manager_config.backend_properties
+    dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
+
+    if dynamical_decoupling is not None:
+        if pass_manager_config.scheduling_method is None:
+            from qiskit.transpiler.passes import ALAPSchedule
+            pass_manager.append(ALAPSchedule(pass_manager_config.instruction_durations))
+        if dynamical_decoupling[:3] in {'udd', 'UDD'}:
+            try:
+                N = int(dynamical_decoupling[4:]) 
+                from qiskit.transpiler.passes import UDDPass
+                pass_manager.append(UDDPass(N, backend_properties, dt_in_sec))
+            except:
+                raise TranspilerError("UDD sequence must be in form of UDD_N, where N is an int.")
+        else:
+            raise TranspilerError("Invalid dynamical decoupling sequence %s." % dynamical_decoupling)
+
     return pass_manager.run(circuit, callback=transpile_config['callback'],
                             output_name=transpile_config['output_name'])
 
@@ -368,7 +392,7 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
 def _parse_transpile_args(circuits, backend,
                           basis_gates, coupling_map, backend_properties,
                           initial_layout, layout_method, routing_method, translation_method,
-                          scheduling_method, instruction_durations,
+                          scheduling_method, instruction_durations, dynamical_decoupling,
                           seed_transpiler, optimization_level,
                           callback, output_name) -> List[Dict]:
     """Resolve the various types of args allowed to the transpile() function through
@@ -402,6 +426,7 @@ def _parse_transpile_args(circuits, backend,
         durations = InstructionDurations.from_backend(backend).update(instruction_durations)
     scheduling_method = _parse_scheduling_method(scheduling_method, num_circuits)
     durations = _parse_instruction_durations(durations, num_circuits)
+    dynamical_decoupling = _parse_dynamical_decoupling_method(dynamical_decoupling, num_circuits)
     seed_transpiler = _parse_seed_transpiler(seed_transpiler, num_circuits)
     optimization_level = _parse_optimization_level(optimization_level, num_circuits)
     output_name = _parse_output_name(output_name, circuits)
@@ -410,7 +435,7 @@ def _parse_transpile_args(circuits, backend,
     list_transpile_args = []
     for args in zip(basis_gates, coupling_map, backend_properties, initial_layout,
                     layout_method, routing_method, translation_method, scheduling_method,
-                    durations, seed_transpiler, optimization_level,
+                    durations, dynamical_decoupling, seed_transpiler, optimization_level,
                     output_name, callback):
         transpile_args = {'pass_manager_config': PassManagerConfig(basis_gates=args[0],
                                                                    coupling_map=args[1],
@@ -421,10 +446,11 @@ def _parse_transpile_args(circuits, backend,
                                                                    translation_method=args[6],
                                                                    scheduling_method=args[7],
                                                                    instruction_durations=args[8],
-                                                                   seed_transpiler=args[9]),
-                          'optimization_level': args[10],
-                          'output_name': args[11],
-                          'callback': args[12]}
+                                                                   dynamical_decoupling=args[9],
+                                                                   seed_transpiler=args[10]),
+                          'optimization_level': args[11],
+                          'output_name': args[12],
+                          'callback': args[13]}
         list_transpile_args.append(transpile_args)
 
     return list_transpile_args
@@ -531,6 +557,12 @@ def _parse_instruction_durations(instruction_durations, num_circuits):
     if not isinstance(instruction_durations, list):
         instruction_durations = [instruction_durations] * num_circuits
     return instruction_durations
+
+
+def _parse_dynamical_decoupling_method(dynamical_decoupling, num_circuits):
+    if not isinstance(dynamical_decoupling, list):
+        dynamical_decoupling = [dynamical_decoupling] * num_circuits
+    return dynamical_decoupling
 
 
 def _parse_seed_transpiler(seed_transpiler, num_circuits):

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -379,13 +379,14 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
                 from qiskit.transpiler.passes import UDDPass
                 if N < 2:
                     raise TranspilerError("UDD must have order of at least 2.")
-                backend_properties = pass_manager_config.backend_properties
-                dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
-                pass_manager.append(UDDPass(N, backend_properties, dt_in_sec))
+                pass_manager.append(
+                        UDDPass(N, pass_manager_config.backend_properties,
+                                        pass_manager_config.instruction_durations.schedule_dt))
             except:
                 raise TranspilerError("UDD sequence must be in form of UDD_N, where N is an int.")
         else:
-            raise TranspilerError("Invalid dynamical decoupling sequence %s." % dynamical_decoupling)
+            raise TranspilerError("Invalid dynamical decoupling sequence %s."
+                                                                % dynamical_decoupling)
 
     return pass_manager.run(circuit, callback=transpile_config['callback'],
                             output_name=transpile_config['output_name'])

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -141,8 +141,8 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             they are overwritten with the instruction_durations.
         dynamical_decoupling: The name of the dynamical decoupling seqeuence to insert into times 
             when the qubit(s) is/are idling for durations longer than the duration of the specified
-            DD seqeuence. The circuit will need to be converted to a schedule before DD sequences 
-            can be inserted. If no scheduling method is provided, 'alap' will be provided 
+            DD sequence. The circuit will need to be converted to a scheduled circuit before DD 
+            sequences can be inserted. If no scheduling method is provided, 'alap' will be provided 
             automatically as the scheduling method.
         seed_transpiler: Sets random seed for the stochastic parts of the transpiler
         optimization_level: How much optimization to perform on the circuits.
@@ -368,8 +368,6 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
         pass_manager.append(RemoveOpsOnIdleQubits())
 
     dynamical_decoupling = pass_manager_config.dynamical_decoupling
-    backend_properties = pass_manager_config.backend_properties
-    dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
 
     if dynamical_decoupling is not None:
         if pass_manager_config.scheduling_method is None:
@@ -379,6 +377,8 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
             try:
                 N = int(dynamical_decoupling[4:]) 
                 from qiskit.transpiler.passes import UDDPass
+                backend_properties = pass_manager_config.backend_properties
+                dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
                 pass_manager.append(UDDPass(N, backend_properties, dt_in_sec))
             except:
                 raise TranspilerError("UDD sequence must be in form of UDD_N, where N is an int.")

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -169,6 +169,9 @@ from .scheduling import ALAPSchedule
 from .scheduling import ASAPSchedule
 from .scheduling import DelayInDt
 
+# dynamical decoupling
+from .dynamical_decoupling import UDDPass
+
 # additional utility passes
 from .utils import CheckMap
 from .utils import CheckCXDirection

--- a/qiskit/transpiler/passes/dynamical_decoupling/__init__.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Module containing dynamical decoupling passes."""
+
+from .uddpass import UDDPass

--- a/qiskit/transpiler/passes/dynamical_decoupling/__init__.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/__init__.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Module containing dynamical decoupling passes."""
+"""Module containing passes of dynamical decoupling, an error mitigation
+technique that attempts to cancel out system-environment interations by
+sending a sequence of pulses."""
 
 from .uddpass import UDDPass

--- a/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from qiskit.circuit.library.standard_gates import XGate, YGate
+from qiskit.circuit.delay import Delay
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler.basepasses import TransformationPass
+
+class UDDPass(TransformationPass):
+
+    def __init__(self, N, backend_properties, dt_in_sec):
+        """UDDPass initializer.
+        Args:
+            N (int): Order of the UDD sequence to implement.
+            backend_properties (BackendProperties): Properties returned by a
+                backend, including information on gate errors, readout errors,
+                qubit coherence times, etc.
+            dt_in_sec (float): Sample duration [sec] used for the conversion.
+        """
+        super().__init__()
+        self.N = N
+        self.backend_properties = backend_properties
+        self.dt = dt_in_sec
+
+    def run(self, dag):
+        """Run the UDD pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): DAG to new DAG.
+
+        Returns:
+            DAGCircuit: A new DAG with UDD Sequences inserted in large 
+                        enough delays.
+        """
+        new_dag = DAGCircuit()
+
+        return new_dag

--- a/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
@@ -57,7 +57,7 @@ class UDDPass(TransformationPass):
         for qubit, props in u3_props.items():
             if 'gate_length' in props:
                 gate_length = props['gate_length'][0]
-                # TODO: Needs to check if total gate duration exceeds the input t_c
+                # TODO: Needs to check if total gate duration exceeds the input tau_c
                 # If so, raise error
                 udd_durations[qubit[0]] = self.tau_c - int(self.N * round(gate_length / self.dt))
 

--- a/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
@@ -80,7 +80,7 @@ class UDDPass(TransformationPass):
             
         for node in dag.topological_op_nodes():
 
-            if isinstance(node.op, Delay):
+            if isinstance(node.op, Delay) and len(dag.ancestors(node)) > 1:
                 delay_duration = node.op.duration
                 udd_duration = tau_step_totals[node.qargs[0].index]
 

--- a/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
@@ -50,7 +50,7 @@ class UDDPass(TransformationPass):
             DAGCircuit: A new DAG with UDD Sequences inserted in large 
                         enough delays.
         """
-        udd_durations = {}
+        tau_step_totals = {}
         tau_steps_dict = {}
 
         u3_props = self.backend_properties._gates['u3']
@@ -59,9 +59,9 @@ class UDDPass(TransformationPass):
                 gate_length = props['gate_length'][0]
                 # TODO: Needs to check if total gate duration exceeds the input tau_c
                 # If so, raise error
-                udd_durations[qubit[0]] = self.tau_c - int(self.N * round(gate_length / self.dt))
+                tau_step_totals[qubit[0]] = self.tau_c - int(self.N * round(gate_length / self.dt))
 
-                t_i = [int(round(udd_durations[qubit[0]] * \
+                t_i = [int(round(tau_step_totals[qubit[0]] * \
                                 (sin(pi * i / (2 * (self.N + 1)))) ** 2)) \
                                 for i in range(self.N + 2)]
 
@@ -82,7 +82,7 @@ class UDDPass(TransformationPass):
 
             if isinstance(node.op, Delay):
                 delay_duration = node.op.duration
-                udd_duration = udd_durations[node.qargs[0].index]
+                udd_duration = tau_step_totals[node.qargs[0].index]
 
                 if self.tau_c <= delay_duration:
                     tau_steps = tau_steps_dict[node.qargs[0].index]

--- a/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
@@ -12,6 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+"""UDD Pass"""
 from qiskit.circuit.library.standard_gates import XGate, YGate
 from qiskit.circuit.delay import Delay
 from qiskit.dagcircuit import DAGCircuit
@@ -20,8 +21,9 @@ from qiskit.transpiler.basepasses import TransformationPass
 from math import sin, pi
 
 class UDDPass(TransformationPass):
+    """UDD Pass"""
 
-    def __init__(self, N, backend_properties, dt_in_sec):
+    def __init__(self, N, backend_properties, dt_in_sec, tau_c=None):
         """UDDPass initializer.
         Args:
             N (int): Order of the UDD sequence to implement.
@@ -29,11 +31,14 @@ class UDDPass(TransformationPass):
                 backend, including information on gate errors, readout errors,
                 qubit coherence times, etc.
             dt_in_sec (float): Sample duration [sec] used for the conversion.
+            tau_c (int): Cycle time of the UDD sequence. Default is 2000 dt if
+                not specified.
         """
         super().__init__()
         self.N = N
         self.backend_properties = backend_properties
         self.dt = dt_in_sec
+        self.tau_c = 2000 if not tau_c else tau_c
 
     def run(self, dag):
         """Run the UDD pass on `dag`.
@@ -45,9 +50,8 @@ class UDDPass(TransformationPass):
             DAGCircuit: A new DAG with UDD Sequences inserted in large 
                         enough delays.
         """
-        tau_c = 2000      # In units of dt
         udd_durations = {}
-        tau_steps = {}
+        tau_steps_dict = {}
 
         u3_props = self.backend_properties._gates['u3']
         for qubit, props in u3_props.items():
@@ -55,16 +59,17 @@ class UDDPass(TransformationPass):
                 gate_length = props['gate_length'][0]
                 # TODO: Needs to check if total gate duration exceeds the input t_c
                 # If so, raise error
-                udd_durations[qubit[0]] = tau_c - int(self.N * round(gate_length / self.dt))
-                t_i = [int(round(udd_durations[qubit[0]] * (sin(pi * i / (2 * (self.N + 1)))) ** 2)) for i in range(self.N + 2)]
-                tau_steps[qubit[0]] = [t_i[i] - t_i[i-1] for i in range(1, self.N + 2)]
+                udd_durations[qubit[0]] = self.tau_c - int(self.N * round(gate_length / self.dt))
+
+                t_i = [int(round(udd_durations[qubit[0]] * \
+                                (sin(pi * i / (2 * (self.N + 1)))) ** 2)) \
+                                for i in range(self.N + 2)]
+
+                tau_steps_dict[qubit[0]] = [t_i[i] - t_i[i-1] for i in range(1, self.N + 2)]
                 # TODO: Maybe check if each tau step is 0, but makes error checking
                 # complicated in case of overflow of sum
                 # TODO: Also maybe check if sum(tau_steps) > udd_duration due to rounding up
                 # too frequently
-
-        for i in range(len(tau_steps)):
-            print(i, tau_steps[i])
 
         new_dag = DAGCircuit()
 
@@ -72,29 +77,29 @@ class UDDPass(TransformationPass):
             new_dag.add_qreg(qreg)
         for creg in dag.cregs.values():
             new_dag.add_creg(creg)
-
             
         for node in dag.topological_op_nodes():
-            print(dag.instruction_durations)
-            if isinstance(node.op, Delay):
-                delay_duration = dag.instruction_durations.get(node.op, node.qargs)
-                udd_duration = udd_durations[node.qargs[0].index]
-                print(udd_duration)
 
-                if tau_c <= delay_duration:
-                    count = int(delay_duration // tau_c)
-                    error = udd_duration - sum(tau_steps)             # Leftover from modulo errors
-                    parity = 1 if (delay_duration - count * tau_c + count * error) % 2 else 0
-                    new_delay = int((delay_duration - count * tau_c + count * error) / 2)
+            if isinstance(node.op, Delay):
+                delay_duration = node.op.duration
+                udd_duration = udd_durations[node.qargs[0].index]
+
+                if self.tau_c <= delay_duration:
+                    tau_steps = tau_steps_dict[node.qargs[0].index]
+                    count = int(delay_duration // self.tau_c)
+                    remainder = udd_duration - sum(tau_steps)
+                    parity = 1 if (delay_duration - count * self.tau_c + count * remainder) % 2 \
+                               else 0
+                    new_delay = int((delay_duration - count * self.tau_c + count * remainder) / 2)
 
                     new_dag.apply_operation_back(Delay(new_delay), qargs=node.qargs)
 
                     for _ in range(count):
-                        new_dag.apply_operation_back(Delay(udd_duration // 4), qargs=node.qargs)
-                        new_dag.apply_operation_back(YGate(), qargs=node.qargs)
-                        new_dag.apply_operation_back(Delay(udd_duration // 2), qargs=node.qargs)
-                        new_dag.apply_operation_back(YGate(), qargs=node.qargs)
-                        new_dag.apply_operation_back(Delay(udd_duration // 4), qargs=node.qargs)
+                        new_dag.apply_operation_back(Delay(tau_steps[0]), qargs=node.qargs)
+                        for tau_step in tau_steps[1:]:
+                            new_dag.apply_operation_back(YGate(), qargs=node.qargs)
+                            new_dag.apply_operation_back(Delay(tau_step), qargs=node.qargs)
+
 
                     new_dag.apply_operation_back(Delay(new_delay + parity), qargs=node.qargs)
 

--- a/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/uddpass.py
@@ -17,6 +17,8 @@ from qiskit.circuit.delay import Delay
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 
+from math import sin, pi
+
 class UDDPass(TransformationPass):
 
     def __init__(self, N, backend_properties, dt_in_sec):
@@ -43,6 +45,63 @@ class UDDPass(TransformationPass):
             DAGCircuit: A new DAG with UDD Sequences inserted in large 
                         enough delays.
         """
+        tau_c = 2000      # In units of dt
+        udd_durations = {}
+        tau_steps = {}
+
+        u3_props = self.backend_properties._gates['u3']
+        for qubit, props in u3_props.items():
+            if 'gate_length' in props:
+                gate_length = props['gate_length'][0]
+                # TODO: Needs to check if total gate duration exceeds the input t_c
+                # If so, raise error
+                udd_durations[qubit[0]] = tau_c - int(self.N * round(gate_length / self.dt))
+                t_i = [int(round(udd_durations[qubit[0]] * (sin(pi * i / (2 * (self.N + 1)))) ** 2)) for i in range(self.N + 2)]
+                tau_steps[qubit[0]] = [t_i[i] - t_i[i-1] for i in range(1, self.N + 2)]
+                # TODO: Maybe check if each tau step is 0, but makes error checking
+                # complicated in case of overflow of sum
+                # TODO: Also maybe check if sum(tau_steps) > udd_duration due to rounding up
+                # too frequently
+
+        for i in range(len(tau_steps)):
+            print(i, tau_steps[i])
+
         new_dag = DAGCircuit()
+
+        for qreg in dag.qregs.values():
+            new_dag.add_qreg(qreg)
+        for creg in dag.cregs.values():
+            new_dag.add_creg(creg)
+
+            
+        for node in dag.topological_op_nodes():
+            print(dag.instruction_durations)
+            if isinstance(node.op, Delay):
+                delay_duration = dag.instruction_durations.get(node.op, node.qargs)
+                udd_duration = udd_durations[node.qargs[0].index]
+                print(udd_duration)
+
+                if tau_c <= delay_duration:
+                    count = int(delay_duration // tau_c)
+                    error = udd_duration - sum(tau_steps)             # Leftover from modulo errors
+                    parity = 1 if (delay_duration - count * tau_c + count * error) % 2 else 0
+                    new_delay = int((delay_duration - count * tau_c + count * error) / 2)
+
+                    new_dag.apply_operation_back(Delay(new_delay), qargs=node.qargs)
+
+                    for _ in range(count):
+                        new_dag.apply_operation_back(Delay(udd_duration // 4), qargs=node.qargs)
+                        new_dag.apply_operation_back(YGate(), qargs=node.qargs)
+                        new_dag.apply_operation_back(Delay(udd_duration // 2), qargs=node.qargs)
+                        new_dag.apply_operation_back(YGate(), qargs=node.qargs)
+                        new_dag.apply_operation_back(Delay(udd_duration // 4), qargs=node.qargs)
+
+                    new_dag.apply_operation_back(Delay(new_delay + parity), qargs=node.qargs)
+
+                else:
+                    new_dag.apply_operation_back(Delay(delay_duration), qargs=node.qargs)
+
+            else:
+                new_dag.apply_operation_back(node.op, node.qargs, node.cargs, node.condition)
 
         return new_dag

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -28,6 +28,7 @@ class PassManagerConfig:
                  translation_method=None,
                  scheduling_method=None,
                  instruction_durations=None,
+                 dynamical_decoupling=None,
                  backend_properties=None,
                  seed_transpiler=None):
         """Initialize a PassManagerConfig object
@@ -47,6 +48,8 @@ class PassManagerConfig:
             scheduling_method (str): the pass to use for scheduling instructions.
             instruction_durations (InstructionDurations): Dictionary of duration
                 (in dt) for each instruction.
+            dynamical_decoupling (str): the pass to use to implement a dynamical
+                decoupling sequences where possible.
             backend_properties (BackendProperties): Properties returned by a
                 backend, including information on gate errors, readout errors,
                 qubit coherence times, etc.
@@ -61,5 +64,6 @@ class PassManagerConfig:
         self.translation_method = translation_method
         self.scheduling_method = scheduling_method
         self.instruction_durations = instruction_durations
+        self.dynamical_decoupling = dynamical_decoupling
         self.backend_properties = backend_properties
         self.seed_transpiler = seed_transpiler

--- a/test/python/transpiler/test_udd.py
+++ b/test/python/transpiler/test_udd.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests UDD Pass"""
+
+from qiskit import QuantumCircuit
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passmanager_config import PassManagerConfig
+from qiskit.transpiler.passes import UDDPass
+from qiskit.test import QiskitTestCase
+from qiskit.test.mock import FakeAlmaden
+
+from math import pi
+
+
+class TestUDD_2(QiskitTestCase):
+    """Test the UDD pass."""
+
+    def setUp(self):
+        self.backend = FakeAlmaden()
+        self.dt_in_sec = self.backend.configuration().dt
+        self.backend_prop = self.backend.properties()
+
+    def test_udd_2(self):
+        """Test the UDD_2 pass.
+
+        It should replace large enough delay blocks with UDD_2 sequences.
+        """
+        circuit = QuantumCircuit(1)
+        circuit.h(0)
+        circuit.delay(2500, 0)
+        circuit.h(0)
+
+        pass_manager = PassManager()
+        pass_manager.append(UDDPass(2, self.backend_prop, self.dt_in_sec))
+        actual = pass_manager.run(circuit)
+        
+        expected = QuantumCircuit(1)
+        expected.h(0)
+        expected.delay(250, 0)
+        expected.delay(340, 0)
+        expected.y(0)
+        expected.delay(680, 0)
+        expected.y(0)
+        expected.delay(340, 0)
+        expected.delay(250, 0)
+        expected.h(0)
+
+        self.assertEqual(actual, expected)
+
+    def test_udd_3(self):
+        """Test the UDD_3 pass.
+
+        It should replace large enough delay blocks with UDD_3 sequences 
+        except for the first delay block.
+        """
+        circuit = QuantumCircuit(1)
+        circuit.delay(2000, 0)
+        circuit.h(0)
+        circuit.delay(2500, 0)
+        circuit.h(0)
+
+        pass_manager = PassManager()
+        pass_manager.append(UDDPass(3, self.backend_prop, self.dt_in_sec))
+        actual = pass_manager.run(circuit)
+        
+        expected = QuantumCircuit(1)
+        expected.delay(2000, 0)
+        expected.h(0)
+        expected.delay(250, 0)
+        expected.delay(152, 0)
+        expected.y(0)
+        expected.delay(368, 0)
+        expected.y(0)
+        expected.delay(368, 0)
+        expected.y(0)
+        expected.delay(152, 0)
+        expected.delay(250, 0)
+        expected.h(0)
+
+        self.assertEqual(actual, expected)
+
+    def test_udd_4(self):
+        """Test the UDD_4 pass.
+
+        It should replace large enough delay blocks with UDD_4 sequences.
+        """
+        circuit = QuantumCircuit(1)
+        circuit.h(0)
+        circuit.delay(100, 0)
+        circuit.x(0)
+        circuit.delay(2500, 0)
+        circuit.h(0)
+
+        pass_manager = PassManager()
+        pass_manager.append(UDDPass(4, self.backend_prop, self.dt_in_sec))
+        actual = pass_manager.run(circuit)
+        
+        expected = QuantumCircuit(1)
+        expected.h(0)
+        expected.delay(100, 0)
+        expected.x(0)
+        expected.delay(250, 0)
+        expected.delay(69, 0)
+        expected.y(0)
+        expected.delay(180, 0)
+        expected.y(0)
+        expected.delay(222, 0)
+        expected.y(0)
+        expected.delay(180, 0)
+        expected.y(0)
+        expected.delay(69, 0)
+        expected.delay(250, 0)
+        expected.h(0)
+
+        self.assertEqual(actual, expected)

--- a/test/python/transpiler/test_udd.py
+++ b/test/python/transpiler/test_udd.py
@@ -21,10 +21,7 @@ from qiskit.transpiler.passes import UDDPass
 from qiskit.test import QiskitTestCase
 from qiskit.test.mock import FakeAlmaden
 
-from math import pi
-
-
-class TestUDD_2(QiskitTestCase):
+class TestUDD(QiskitTestCase):
     """Test the UDD pass."""
 
     def setUp(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds another optional parameter to the `transpile(..., dynamical_decoupling=None, ...)` function such that users will be able to call upon a DD sequence to add to their Quantum Circuit. This PR deals specifically with the Uhrig DD (UDD) Pass addition to the transpiler. Users will be able to get a circuit with DD inserted into places where there are large enough delays between operations in the input circuit. Users will have to specify the order of the UDD sequence he or she would like to use in the form of 'UDD_N', where N is an integer greater than or equal to 2.

`circuit_with_dd = transpile(input_circuit, backend, dynamical_decoupling='UDD_N')`


### Details and comments
TODOs:
- [x] Create the UDD Pass class
- [x] Edit the Transpiler to include the DD parameter
- [x] Add Tests
- [x] Find way to calculate duration of UDD sequence with backend configurations
- [x] Make leftover delay symmetric (front and back) with respect to DD sequence
- [ ] Raise an error when the total duration of the gates in the UDD_N sequence exceed the specified cycle time
- [x] Don't insert UDD_N sequence when qubit is in ground state or first excited.