### PR TITLE
Add cdd to transpiler

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -141,8 +141,8 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             they are overwritten with the instruction_durations.
         dynamical_decoupling: The name of the dynamical decoupling seqeuence to insert into times 
             when the qubit(s) is/are idling for durations longer than the duration of the specified
-            DD seqeuence. The circuit will need to be converted to a schedule before DD sequences 
-            can be inserted. If no scheduling method is provided, 'alap' will be provided 
+            DD sequence. The circuit will need to be converted to a scheduled circuit before DD 
+            sequences can be inserted. If no scheduling method is provided, 'alap' will be provided 
             automatically as the scheduling method.
         seed_transpiler: Sets random seed for the stochastic parts of the transpiler
         optimization_level: How much optimization to perform on the circuits.
@@ -368,8 +368,6 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
         pass_manager.append(RemoveOpsOnIdleQubits())
 
     dynamical_decoupling = pass_manager_config.dynamical_decoupling
-    backend_properties = pass_manager_config.backend_properties
-    dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
 
     if dynamical_decoupling is not None:
         if pass_manager_config.scheduling_method is None:
@@ -379,6 +377,8 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
             try:
                 N = int(dynamical_decoupling[4:]) 
                 from qiskit.transpiler.passes import CDDPass
+                backend_properties = pass_manager_config.backend_properties
+                dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
                 pass_manager.append(CDDPass(N, backend_properties, dt_in_sec))
             except:
                 raise TranspilerError("CDD sequence must be in form of UDD_N, where N is an int.")

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -379,13 +379,14 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
                 if N < 1:
                     raise TranspilerError("CDD order must be at least 1.") 
                 from qiskit.transpiler.passes import CDDPass
-                backend_properties = pass_manager_config.backend_properties
-                dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
-                pass_manager.append(CDDPass(N, backend_properties, dt_in_sec))
+                pass_manager.append(
+                    CDDPass(N, pass_manager_config.backend_properties,
+                                    pass_manager_config.instruction_durations.schedule_dt))
             except:
                 raise TranspilerError("CDD sequence must be in form of UDD_N, where N is an int.")
         else:
-            raise TranspilerError("Invalid dynamical decoupling sequence %s." % dynamical_decoupling)
+            raise TranspilerError("Invalid dynamical decoupling sequence %s." 
+                                                                    % dynamical_decoupling)
 
     return pass_manager.run(circuit, callback=transpile_config['callback'],
                             output_name=transpile_config['output_name'])

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -139,7 +139,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             E.g. [('cx', [0, 1], 1000), ('u3', [0], 300)]
             Durations defined in ``backend.properties`` are used as default and
             they are overwritten with the instruction_durations.
-        dynamical_decoupling: The name of the dynamical decoupling seqeuence to insert into times 
+        dynamical_decoupling: The name of the dynamical decoupling sequence to insert into times 
             when the qubit(s) is/are idling for durations longer than the duration of the specified
             DD sequence. The circuit will need to be converted to a scheduled circuit before DD 
             sequences can be inserted. If no scheduling method is provided, 'alap' will be provided 
@@ -375,7 +375,9 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
             pass_manager.append(ALAPSchedule(pass_manager_config.instruction_durations))
         if dynamical_decoupling[:3] in {'cdd', 'CDD'}:
             try:
-                N = int(dynamical_decoupling[4:]) 
+                N = int(dynamical_decoupling[4:])
+                if N < 1:
+                    raise TranspileError("CDD order must be at least 1.") 
                 from qiskit.transpiler.passes import CDDPass
                 backend_properties = pass_manager_config.backend_properties
                 dt_in_sec = pass_manager_config.instruction_durations.schedule_dt

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -52,6 +52,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
               translation_method: Optional[str] = None,
               scheduling_method: Optional[str] = None,
               instruction_durations: Optional[InstructionDurationsType] = None,
+              dynamical_decoupling: Optional[str] = None,
               seed_transpiler: Optional[int] = None,
               optimization_level: Optional[int] = None,
               pass_manager: Optional[PassManager] = None,
@@ -138,6 +139,11 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             E.g. [('cx', [0, 1], 1000), ('u3', [0], 300)]
             Durations defined in ``backend.properties`` are used as default and
             they are overwritten with the instruction_durations.
+        dynamical_decoupling: The name of the dynamical decoupling seqeuence to insert into times 
+            when the qubit(s) is/are idling for durations longer than the duration of the specified
+            DD seqeuence. The circuit will need to be converted to a schedule before DD sequences 
+            can be inserted. If no scheduling method is provided, 'alap' will be provided 
+            automatically as the scheduling method.
         seed_transpiler: Sets random seed for the stochastic parts of the transpiler
         optimization_level: How much optimization to perform on the circuits.
             Higher levels generate more optimized circuits,
@@ -232,8 +238,8 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
                                            backend_properties, initial_layout,
                                            layout_method, routing_method, translation_method,
                                            scheduling_method, instruction_durations,
-                                           seed_transpiler, optimization_level,
-                                           callback, output_name)
+                                           dynamical_decoupling, seed_transpiler,
+                                           optimization_level, callback, output_name)
 
     _check_circuits_coupling_map(circuits, transpile_args, backend)
 
@@ -348,7 +354,7 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
         pass_manager = level_2_pass_manager(pass_manager_config)
     elif level == 3:
         pass_manager = level_3_pass_manager(pass_manager_config)
-    else:
+    else: 
         raise TranspilerError("optimization_level can range from 0 to 3.")
 
     if ms_basis_swap is not None:
@@ -361,6 +367,24 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
         from qiskit.transpiler.passes.scheduling import RemoveOpsOnIdleQubits
         pass_manager.append(RemoveOpsOnIdleQubits())
 
+    dynamical_decoupling = pass_manager_config.dynamical_decoupling
+    backend_properties = pass_manager_config.backend_properties
+    dt_in_sec = pass_manager_config.instruction_durations.schedule_dt
+
+    if dynamical_decoupling is not None:
+        if pass_manager_config.scheduling_method is None:
+            from qiskit.transpiler.passes import ALAPSchedule
+            pass_manager.append(ALAPSchedule(pass_manager_config.instruction_durations))
+        if dynamical_decoupling[:3] in {'cdd', 'CDD'}:
+            try:
+                N = int(dynamical_decoupling[4:]) 
+                from qiskit.transpiler.passes import CDDPass
+                pass_manager.append(CDDPass(N, backend_properties, dt_in_sec))
+            except:
+                raise TranspilerError("CDD sequence must be in form of UDD_N, where N is an int.")
+        else:
+            raise TranspilerError("Invalid dynamical decoupling sequence %s." % dynamical_decoupling)
+
     return pass_manager.run(circuit, callback=transpile_config['callback'],
                             output_name=transpile_config['output_name'])
 
@@ -368,7 +392,7 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
 def _parse_transpile_args(circuits, backend,
                           basis_gates, coupling_map, backend_properties,
                           initial_layout, layout_method, routing_method, translation_method,
-                          scheduling_method, instruction_durations,
+                          scheduling_method, instruction_durations, dynamical_decoupling,
                           seed_transpiler, optimization_level,
                           callback, output_name) -> List[Dict]:
     """Resolve the various types of args allowed to the transpile() function through
@@ -402,6 +426,7 @@ def _parse_transpile_args(circuits, backend,
         durations = InstructionDurations.from_backend(backend).update(instruction_durations)
     scheduling_method = _parse_scheduling_method(scheduling_method, num_circuits)
     durations = _parse_instruction_durations(durations, num_circuits)
+    dynamical_decoupling = _parse_dynamical_decoupling_method(dynamical_decoupling, num_circuits)
     seed_transpiler = _parse_seed_transpiler(seed_transpiler, num_circuits)
     optimization_level = _parse_optimization_level(optimization_level, num_circuits)
     output_name = _parse_output_name(output_name, circuits)
@@ -410,7 +435,7 @@ def _parse_transpile_args(circuits, backend,
     list_transpile_args = []
     for args in zip(basis_gates, coupling_map, backend_properties, initial_layout,
                     layout_method, routing_method, translation_method, scheduling_method,
-                    durations, seed_transpiler, optimization_level,
+                    durations, dynamical_decoupling, seed_transpiler, optimization_level,
                     output_name, callback):
         transpile_args = {'pass_manager_config': PassManagerConfig(basis_gates=args[0],
                                                                    coupling_map=args[1],
@@ -421,10 +446,11 @@ def _parse_transpile_args(circuits, backend,
                                                                    translation_method=args[6],
                                                                    scheduling_method=args[7],
                                                                    instruction_durations=args[8],
-                                                                   seed_transpiler=args[9]),
-                          'optimization_level': args[10],
-                          'output_name': args[11],
-                          'callback': args[12]}
+                                                                   dynamical_decoupling=args[9],
+                                                                   seed_transpiler=args[10]),
+                          'optimization_level': args[11],
+                          'output_name': args[12],
+                          'callback': args[13]}
         list_transpile_args.append(transpile_args)
 
     return list_transpile_args
@@ -531,6 +557,12 @@ def _parse_instruction_durations(instruction_durations, num_circuits):
     if not isinstance(instruction_durations, list):
         instruction_durations = [instruction_durations] * num_circuits
     return instruction_durations
+
+
+def _parse_dynamical_decoupling_method(dynamical_decoupling, num_circuits):
+    if not isinstance(dynamical_decoupling, list):
+        dynamical_decoupling = [dynamical_decoupling] * num_circuits
+    return dynamical_decoupling
 
 
 def _parse_seed_transpiler(seed_transpiler, num_circuits):

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -377,7 +377,7 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
             try:
                 N = int(dynamical_decoupling[4:])
                 if N < 1:
-                    raise TranspileError("CDD order must be at least 1.") 
+                    raise TranspilerError("CDD order must be at least 1.") 
                 from qiskit.transpiler.passes import CDDPass
                 backend_properties = pass_manager_config.backend_properties
                 dt_in_sec = pass_manager_config.instruction_durations.schedule_dt

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -169,6 +169,9 @@ from .scheduling import ALAPSchedule
 from .scheduling import ASAPSchedule
 from .scheduling import DelayInDt
 
+# dynamical decoupling
+from .dynamical_decoupling import CDDPass
+
 # additional utility passes
 from .utils import CheckMap
 from .utils import CheckCXDirection

--- a/qiskit/transpiler/passes/dynamical_decoupling/__init__.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/__init__.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Module containing dynamical decoupling passes."""
+"""Module containing passes of dynamical decoupling, an error mitigation
+technique that attempts to cancel out system-environment interations by
+sending a sequence of pulses."""
 
 from .cddpass import CDDPass

--- a/qiskit/transpiler/passes/dynamical_decoupling/__init__.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Module containing dynamical decoupling passes."""
+
+from .cddpass import CDDPass

--- a/qiskit/transpiler/passes/dynamical_decoupling/cddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/cddpass.py
@@ -87,7 +87,7 @@ class CDDPass(TransformationPass):
 
         for node in dag.topological_op_nodes():
 
-            if isinstance(node.op, Delay):
+            if isinstance(node.op, Delay) and len(dag.ancestors(node)) > 1:
                 delay_duration = node.op.duration
                 self.tau_step_total = self.tau_step_totals[node.qargs[0].index]
                 tau_c = self.tau_cs[node.qargs[0].index] if self.tau_c is None else self.tau_c

--- a/qiskit/transpiler/passes/dynamical_decoupling/cddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/cddpass.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from qiskit.circuit.library.standard_gates import XGate, YGate
+from qiskit.circuit.delay import Delay
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler.basepasses import TransformationPass
+
+class CDDPass(TransformationPass):
+
+    def __init__(self, N, backend_properties, dt_in_sec):
+        """CDDPass initializer.
+        Args:
+            N (int): Order of the CDD sequence to implement.
+            backend_properties (BackendProperties): Properties returned by a
+                backend, including information on gate errors, readout errors,
+                qubit coherence times, etc.
+            dt_in_sec (float): Sample duration [sec] used for the conversion.
+        """
+        super().__init__()
+        self.N = N
+        self.backend_properties = backend_properties
+        self.dt = dt_in_sec
+
+    def run(self, dag):
+        """Run the CDD pass on `dag`.
+        Args:
+            dag (DAGCircuit): DAG to new DAG.
+        Returns:
+            DAGCircuit: A new DAG with CDD Sequences inserted in large 
+                        enough delays.
+        """
+        def build_sequence(N):
+            if N == 1:
+                return [XGate(), YGate(), XGate(), YGate()]
+            return [XGate()] + build_sequence(N-1) + [YGate()] + build_sequence(N-1) + [XGate()] + build_sequence(N-1) + [YGate()] + build_sequence(N-1)
+
+        
+        cdd_durations = {}                        # TODO
+        cdd_sequence = build_sequence(self.N)
+        print("CDD", CDD_sequence)
+        tau_c = 5840
+
+        u3_props = self.backend_properties._gates['u3']
+        for qubit, props in u3_props.items():
+            if 'gate_length' in props:
+                gate_length = props['gate_length'][0]
+                # TODO: Needs to check if durations of gates exceed cycle time
+                # If so, raise error
+                cdd_durations[qubit[0]] = tau_c - int((4 ** self.N) * round(gate_length / self.dt))
+
+        new_dag = DAGCircuit()
+
+        for qreg in dag.qregs.values():
+            new_dag.add_qreg(qreg)
+        for creg in dag.cregs.values():
+            new_dag.add_creg(creg)
+
+        print(dag.instruction_durations)
+
+        for node in dag.topological_op_nodes():
+
+            if isinstance(node.op, Delay):
+                delay_duration = dag.instruction_durations.get(node.op, node.qargs)
+                cdd_duration = cdd_durations[node.qargs[0].index]
+
+                if tau_c <= delay_duration:
+                    count = int(delay_duration // tau_c)
+                    cdd_delay = cdd_duration // len(cdd_sequence)
+                    error = cdd_duration - len(cdd_sequence) * cdd_delay
+                    parity = 1 if (delay_duration - count * tau_c + error + cdd_delay) % 2 else 0
+                    new_delay = int((delay_duration - count * tau_c + error + cdd_delay) / 2)
+
+                    new_dag.apply_operation_back(Delay(new_delay - cdd_delay), qargs=node.qargs)
+
+                    for _ in range(count):
+                        for gate in CDD_sequence:
+                            new_dag.apply_operation_back(Delay(cdd_delay), qargs=node.qargs)
+                            new_dag.apply_operation_back(gate, qargs=node.qargs)
+
+                    new_dag.apply_operation_back(Delay(new_delay + parity), qargs=node.qargs)
+
+                else:
+                    new_dag.apply_operation_back(Delay(delay_duration), qargs=node.qargs)
+
+            else:
+                new_dag.apply_operation_back(node.op, node.qargs, node.cargs, node.condition)
+
+        new_dag.name = dag.name
+        new_dag.instruction_durations = dag.instruction_durations
+
+        return new_dag

--- a/qiskit/transpiler/passes/dynamical_decoupling/cddpass.py
+++ b/qiskit/transpiler/passes/dynamical_decoupling/cddpass.py
@@ -12,14 +12,16 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+"""CDD Pass"""
 from qiskit.circuit.library.standard_gates import XGate, YGate
 from qiskit.circuit.delay import Delay
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 
 class CDDPass(TransformationPass):
+    """CDD Pass"""
 
-    def __init__(self, N, backend_properties, dt_in_sec):
+    def __init__(self, N, backend_properties, dt_in_sec, tau_c=None, tau_step=10):
         """CDDPass initializer.
         Args:
             N (int): Order of the CDD sequence to implement.
@@ -27,11 +29,46 @@ class CDDPass(TransformationPass):
                 backend, including information on gate errors, readout errors,
                 qubit coherence times, etc.
             dt_in_sec (float): Sample duration [sec] used for the conversion.
+            tau_c (int): Cycle time of the DD sequence. Default is the sum of gate
+                durations of DD sequences with 10 ns delays in between.
+            tau_step (float): Delay time between pulses in the DD sequence. Default
+                is 10 ns.
         """
         super().__init__()
         self.N = N
         self.backend_properties = backend_properties
         self.dt = dt_in_sec
+        self.tau_step = tau_step
+        self.tau_cs = {}
+        self.tau_step_totals = {}
+        self.tau_c = tau_c
+
+        def build_sequence(N: int):
+            """
+            Recursively builds a list of gates to represent the CDD sequence
+            for the given order N (int).
+            """
+            if N == 1:
+                return [XGate(), YGate(), XGate(), YGate()]
+            return [XGate()] + build_sequence(N-1) + [YGate()] + build_sequence(N-1) + \
+                   [XGate()] + build_sequence(N-1) + [YGate()] + build_sequence(N-1)
+
+        self.cdd_sequence = build_sequence(self.N)
+
+        u3_props = self.backend_properties._gates['u3']
+        for qubit, props in u3_props.items():
+            if 'gate_length' in props:
+                gate_length = props['gate_length'][0]
+                # TODO: Needs to check if durations of gates exceed cycle time
+                # If so, raise error
+                if tau_c is None:
+                    self.tau_cs[qubit[0]] = len(self.cdd_sequence) * \
+                                        (round(tau_step * 1e-9 / self.dt + gate_length / self.dt))
+                    self.tau_step_totals[qubit[0]] = self.tau_cs[qubit[0]] - \
+                                            round(len(self.cdd_sequence) * gate_length / self.dt)
+                else:
+                    self.tau_step_totals[qubit[0]] = tau_c - \
+                                            round(len(self.cdd_sequence) * gate_length / self.dt)
 
     def run(self, dag):
         """Run the CDD pass on `dag`.
@@ -41,25 +78,6 @@ class CDDPass(TransformationPass):
             DAGCircuit: A new DAG with CDD Sequences inserted in large 
                         enough delays.
         """
-        def build_sequence(N):
-            if N == 1:
-                return [XGate(), YGate(), XGate(), YGate()]
-            return [XGate()] + build_sequence(N-1) + [YGate()] + build_sequence(N-1) + [XGate()] + build_sequence(N-1) + [YGate()] + build_sequence(N-1)
-
-        
-        cdd_durations = {}                        # TODO
-        cdd_sequence = build_sequence(self.N)
-        print("CDD", CDD_sequence)
-        tau_c = 5840
-
-        u3_props = self.backend_properties._gates['u3']
-        for qubit, props in u3_props.items():
-            if 'gate_length' in props:
-                gate_length = props['gate_length'][0]
-                # TODO: Needs to check if durations of gates exceed cycle time
-                # If so, raise error
-                cdd_durations[qubit[0]] = tau_c - int((4 ** self.N) * round(gate_length / self.dt))
-
         new_dag = DAGCircuit()
 
         for qreg in dag.qregs.values():
@@ -67,26 +85,26 @@ class CDDPass(TransformationPass):
         for creg in dag.cregs.values():
             new_dag.add_creg(creg)
 
-        print(dag.instruction_durations)
-
         for node in dag.topological_op_nodes():
 
             if isinstance(node.op, Delay):
-                delay_duration = dag.instruction_durations.get(node.op, node.qargs)
-                cdd_duration = cdd_durations[node.qargs[0].index]
+                delay_duration = node.op.duration
+                self.tau_step_total = self.tau_step_totals[node.qargs[0].index]
+                tau_c = self.tau_cs[node.qargs[0].index] if self.tau_c is None else self.tau_c
 
                 if tau_c <= delay_duration:
-                    count = int(delay_duration // tau_c)
-                    cdd_delay = cdd_duration // len(cdd_sequence)
-                    error = cdd_duration - len(cdd_sequence) * cdd_delay
-                    parity = 1 if (delay_duration - count * tau_c + error + cdd_delay) % 2 else 0
-                    new_delay = int((delay_duration - count * tau_c + error + cdd_delay) / 2)
+                    count = delay_duration // tau_c
+                    tau_step = self.tau_step_total // len(self.cdd_sequence)
+                    remainder = self.tau_step_total % len(self.cdd_sequence)
+                    parity = 1 if (delay_duration - count * (tau_c - remainder) + tau_step) % 2 \
+                               else 0
+                    new_delay = (delay_duration - count * (tau_c - remainder) + tau_step) // 2
 
-                    new_dag.apply_operation_back(Delay(new_delay - cdd_delay), qargs=node.qargs)
+                    new_dag.apply_operation_back(Delay(new_delay - tau_step), qargs=node.qargs)
 
                     for _ in range(count):
-                        for gate in CDD_sequence:
-                            new_dag.apply_operation_back(Delay(cdd_delay), qargs=node.qargs)
+                        for gate in self.cdd_sequence:
+                            new_dag.apply_operation_back(Delay(tau_step), qargs=node.qargs)
                             new_dag.apply_operation_back(gate, qargs=node.qargs)
 
                     new_dag.apply_operation_back(Delay(new_delay + parity), qargs=node.qargs)

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -28,6 +28,7 @@ class PassManagerConfig:
                  translation_method=None,
                  scheduling_method=None,
                  instruction_durations=None,
+                 dynamical_decoupling=None,
                  backend_properties=None,
                  seed_transpiler=None):
         """Initialize a PassManagerConfig object
@@ -47,6 +48,8 @@ class PassManagerConfig:
             scheduling_method (str): the pass to use for scheduling instructions.
             instruction_durations (InstructionDurations): Dictionary of duration
                 (in dt) for each instruction.
+            dynamical_decoupling (str): the pass to use to implement a dynamical
+                decoupling sequences where possible.
             backend_properties (BackendProperties): Properties returned by a
                 backend, including information on gate errors, readout errors,
                 qubit coherence times, etc.
@@ -61,5 +64,6 @@ class PassManagerConfig:
         self.translation_method = translation_method
         self.scheduling_method = scheduling_method
         self.instruction_durations = instruction_durations
+        self.dynamical_decoupling = dynamical_decoupling
         self.backend_properties = backend_properties
         self.seed_transpiler = seed_transpiler

--- a/test/python/transpiler/test_cdd.py
+++ b/test/python/transpiler/test_cdd.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests CDD Pass"""
+
+from qiskit import QuantumCircuit
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passmanager_config import PassManagerConfig
+from qiskit.transpiler.passes import CDDPass
+from qiskit.test import QiskitTestCase
+from qiskit.test.mock import FakeAlmaden
+
+class TestCDD(QiskitTestCase):
+    """Test the CDD pass."""
+
+    def setUp(self):
+        self.backend = FakeAlmaden()
+        self.dt_in_sec = self.backend.configuration().dt
+        self.backend_prop = self.backend.properties()
+
+    def test_cdd_1(self):
+        """Test the CDD_1 pass.
+
+        It should replace large enough delay blocks with CDD_1 sequences.
+        except for the first delay block.
+        """
+        circuit = QuantumCircuit(1)
+        circuit.delay(2000, 0)
+        circuit.h(0)
+        circuit.delay(2000, 0)
+        circuit.h(0)
+
+        pass_manager = PassManager()
+        pass_manager.append(CDDPass(1, self.backend_prop, self.dt_in_sec))
+        actual = pass_manager.run(circuit)
+        
+        expected = QuantumCircuit(1)
+        expected.delay(2000, 0)
+        expected.h(0)
+        expected.delay(247, 0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(293, 0)
+        expected.h(0)
+
+        self.assertEqual(actual, expected)
+
+    def test_cdd_2(self):
+        """Test the CDD_2 pass.
+
+        It should replace large enough delay blocks with CDD_2 sequences.
+        """
+        circuit = QuantumCircuit(1)
+        circuit.h(0)
+        circuit.delay(7500, 0)
+        circuit.h(0)
+        circuit.delay(100, 0)
+        circuit.h(0)
+
+        pass_manager = PassManager()
+        pass_manager.append(CDDPass(2, self.backend_prop, self.dt_in_sec))
+        actual = pass_manager.run(circuit)
+        
+        expected = QuantumCircuit(1)
+        expected.h(0)
+        expected.delay(77, 0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(45, 0)
+        expected.x(0)
+        expected.delay(45, 0)
+        expected.y(0)
+        expected.delay(123, 0)
+        expected.h(0)
+        expected.delay(100, 0)
+        expected.h(0)
+
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds another optional parameter to the `transpile(..., dynamical_decoupling=None, ...)` function such that users will be able to call upon a DD sequence to add to their Quantum Circuit. This PR deals specifically with the Concatentated DD (CDD) Pass addition to the transpiler. Users will be able to get a circuit with DD inserted into places where there are large enough delays between operations in the input circuit. Users will have to specify the order of the CDD sequence he or she would like to use in the form of 'CDD_N', where N is an integer greater than or equal to 1.

`circuit_with_dd = transpile(input_circuit, backend, dynamical_decoupling='CDD_N')`


### Details and comments
TODOs:
- [x] Create the CDD Pass class
- [x] Edit the Transpiler to include the DD parameter
- [x] Add Tests
- [x] Find way to calculate duration of CDD sequence with backend configurations
- [x] Make leftover delay symmetric (front and back) with respect to DD sequence
- [ ] Raise an error when the total duration of the gates in the CDD sequence exceed the specified cycle time
- [x] Don't insert CDD sequence when qubit is in ground state or first excited.