### PR TITLE
Refactoring to around the time unit

### DIFF
--- a/qiskit/assembler/assemble_circuits.py
+++ b/qiskit/assembler/assemble_circuits.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Tuple
 from qiskit.assembler.run_config import RunConfig
 from qiskit.assembler.assemble_schedules import _assemble_instructions as _assemble_schedule
 from qiskit.circuit import QuantumCircuit
+from qiskit.exceptions import QiskitError
 from qiskit.qobj import (QasmQobj, QobjExperimentHeader,
                          QasmQobjInstruction, QasmQobjExperimentConfig, QasmQobjExperiment,
                          QasmQobjConfig, QasmExperimentCalibrations, GateCalibration,
@@ -39,7 +40,14 @@ def _assemble_circuit(
 
     Returns:
         One experiment for the QasmQobj, and pulse library for pulse gates (which could be None)
+
+    Raises:
+        QiskitError: when the circuit has unit other than 'dt'.
     """
+    if circuit.unit != 'dt':
+        raise QiskitError("Unable to assemble circuit with unit '{}', which must be 'dt'."
+                          .format(circuit.unit))
+
     # header data
     num_qubits = 0
     memory_slots = 0

--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -24,7 +24,10 @@ class Delay(Instruction):
     def __init__(self, duration, unit='dt'):
         """Create new delay instruction."""
         if not isinstance(duration, (float, int)):
-            raise CircuitError('Invalid duration type.')
+            raise CircuitError('Unsupported duration type.')
+
+        if unit == 'dt' and not isinstance(duration, int):
+            raise CircuitError("Integer duration is required for 'dt' unit.")
 
         if unit not in {'s', 'ms', 'us', 'ns', 'ps', 'dt'}:
             raise CircuitError('Unknown unit %s is specified.' % unit)

--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -32,8 +32,7 @@ class Delay(Instruction):
         if unit not in {'s', 'ms', 'us', 'ns', 'ps', 'dt'}:
             raise CircuitError('Unknown unit %s is specified.' % unit)
 
-        super().__init__("delay", 1, 0, params=[duration])
-        self.unit = unit
+        super().__init__("delay", 1, 0, params=[duration], unit=unit)
 
     def inverse(self):
         """Special case. Return self."""

--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -21,12 +21,12 @@ from qiskit.circuit.instruction import Instruction
 class Delay(Instruction):
     """Do nothing and just delay/wait/idle for a specified duration."""
 
-    def __init__(self, duration, unit=None):
+    def __init__(self, duration, unit='dt'):
         """Create new delay instruction."""
         if not isinstance(duration, (float, int)):
             raise CircuitError('Invalid duration type.')
 
-        if unit not in {None, 's', 'ms', 'us', 'ns', 'ps', 'dt'}:
+        if unit not in {'s', 'ms', 'us', 'ns', 'ps', 'dt'}:
             raise CircuitError('Unknown unit %s is specified.' % unit)
 
         super().__init__("delay", 1, 0, params=[duration])

--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -16,7 +16,6 @@ Delay instruction (for circuit module).
 import numpy as np
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.instruction import Instruction
-from qiskit.util import apply_prefix
 
 
 class Delay(Instruction):
@@ -27,11 +26,7 @@ class Delay(Instruction):
         if not isinstance(duration, (float, int)):
             raise CircuitError('Invalid duration type.')
 
-        if unit and unit in {'ms', 'us', 'ns', 'ps'}:
-            duration = apply_prefix(duration, unit)
-            unit = 's'
-
-        if unit and unit != 's':
+        if unit not in {None, 's', 'ms', 'us', 'ns', 'ps', 'dt'}:
             raise CircuitError('Unknown unit %s is specified.' % unit)
 
         super().__init__("delay", 1, 0, params=[duration])

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -36,7 +36,6 @@ from itertools import zip_longest
 
 import numpy
 
-from qiskit.exceptions import QiskitError
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.classicalregister import ClassicalRegister
@@ -209,10 +208,6 @@ class Instruction:
 
     def assemble(self):
         """Assemble a QasmQobjInstruction"""
-        if self.unit != 'dt':
-            raise QiskitError("Unable to assemble instructions with unit '{}', which must be 'dt'."
-                              .format(self.unit))
-
         instruction = QasmQobjInstruction(name=self.name)
         # Evaluate parameters
         if self.params:

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -36,6 +36,7 @@ from itertools import zip_longest
 
 import numpy
 
+from qiskit.exceptions import QiskitError
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.classicalregister import ClassicalRegister
@@ -208,6 +209,10 @@ class Instruction:
 
     def assemble(self):
         """Assemble a QasmQobjInstruction"""
+        if self.unit != 'dt':
+            raise QiskitError("Unable to assemble instructions with unit '{}', which must be 'dt'."
+                              .format(self.unit))
+
         instruction = QasmQobjInstruction(name=self.name)
         # Evaluate parameters
         if self.params:

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -49,7 +49,7 @@ _CUTOFF_PRECISION = 1E-10
 class Instruction:
     """Generic quantum instruction."""
 
-    def __init__(self, name, num_qubits, num_clbits, params, duration=None):
+    def __init__(self, name, num_qubits, num_clbits, params, duration=None, unit='dt'):
         """Create a new instruction.
 
         Args:
@@ -58,7 +58,8 @@ class Instruction:
             num_clbits (int): instruction's clbit width
             params (list[int|float|complex|str|ndarray|list|ParameterExpression]):
                 list of parameters
-            duration (float): instruction's duration in seconds.
+            duration (float|int): instruction's duration. it must be integer if ``unit`` is 'dt'
+            unit (str): time unit of duration
 
         Raises:
             CircuitError: when the register is not in the correct format.
@@ -81,7 +82,9 @@ class Instruction:
         # empty definition means opaque or fundamental instruction
         self._definition = None
         self.params = params
+
         self._duration = duration
+        self._unit = unit
 
     def __eq__(self, other):
         """Two instructions are the same if they have the same name,
@@ -192,6 +195,16 @@ class Instruction:
     def duration(self, duration):
         """Set the duration."""
         self._duration = duration
+
+    @property
+    def unit(self):
+        """Get the time unit of duration."""
+        return self._unit
+
+    @unit.setter
+    def unit(self, unit):
+        """Set the time unit of duration."""
+        self._unit = unit
 
     def assemble(self):
         """Assemble a QasmQobjInstruction"""

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -175,6 +175,7 @@ class QuantumCircuit:
         self.global_phase = global_phase
 
         self.duration = None
+        self.unit = 'dt'
 
     @property
     def data(self):
@@ -305,6 +306,7 @@ class QuantumCircuit:
             reverse_circ._append(inst.reverse_ops(), qargs, cargs)
 
         reverse_circ.duration = self.duration
+        reverse_circ.unit = self.unit
         return reverse_circ
 
     def reverse_bits(self):
@@ -848,6 +850,7 @@ class QuantumCircuit:
 
         # mark as normal circuit if a new instruction is added
         self.duration = None
+        self.unit = 'dt'
 
         return instruction
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1954,15 +1954,15 @@ class QuantumCircuit:
 
         return self.append(Barrier(len(qubits)), qubits, [])
 
-    def delay(self, duration, qarg=None, unit=None):
+    def delay(self, duration, qarg=None, unit='dt'):
         """Apply :class:`~qiskit.circuit.Delay`. If qarg is None, applies to all qubits.
         When applying to multiple qubits, delays with the same duration will be created.
 
         Args:
             duration (int or float): duration of the delay.
             qarg (Object): qubit argument to apply this delay.
-            unit (str): unit of the duration. Default unit is ``None``, i.e. unitless.
-                Supported units: 's', 'ms', 'us', 'ns', 'ps'.
+            unit (str): unit of the duration. Supported units: 's', 'ms', 'us', 'ns', 'ps', 'dt'.
+                Default is ``dt``, i.e. time unit depending on the target backend.
 
         Returns:
             qiskit.Instruction: the attached delay instruction.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1962,7 +1962,7 @@ class QuantumCircuit:
             duration (int or float): duration of the delay.
             qarg (Object): qubit argument to apply this delay.
             unit (str): unit of the duration. Supported units: 's', 'ms', 'us', 'ns', 'ps', 'dt'.
-                Default is ``dt``, i.e. time unit depending on the target backend.
+                Default is ``dt``, i.e. integer time unit depending on the target backend.
 
         Returns:
             qiskit.Instruction: the attached delay instruction.

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -131,12 +131,16 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             * ``'as_late_as_possible'``: Schedule instructions late, i.e. keeping qubits
             in the ground state when possible. (alias: ``'alap'``)
             If ``None``, no scheduling will be done.
-        instruction_durations: Durations of instructions. Duration must be the number of ``dt``s.
-            Note that ``dt`` depends on backend configuration. Instruction is specified by
-            a pair of basic instruction name and its acting physical qubits.
-            E.g. [('cx', [0, 1], 1000), ('u3', [0], 300)]
-            Durations defined in ``backend.properties`` are used as default and
-            they are overwritten with the instruction_durations.
+        instruction_durations: Durations of instructions.
+            The gate lengths defined in ``backend.properties`` are used as default and
+            they are updated (overwritten) if this ``instruction_durations`` is specified.
+            The format of ``instruction_durations`` must be as follows.
+            The instruction have to be a pair of instruction name and its acting physical qubits.
+            The duration have to be a pair of length and its time unit. E.g.
+            | [('cx', [0, 1], 1000), ('u3', [0], 300)]
+            | [('cx', [0, 1], 12.3, 'ns'), ('u3', [0], 4.56, 'ns')]
+            If unit is omitted, the default is 'dt', which is a sample time depending on backend.
+            If the time unit is 'dt', the length must be integer.
         seed_transpiler: Sets random seed for the stochastic parts of the transpiler
         optimization_level: How much optimization to perform on the circuits.
             Higher levels generate more optimized circuits,

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -136,7 +136,6 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             The gate lengths defined in ``backend.properties`` are used as default and
             they are updated (overwritten) if this ``instruction_durations`` is specified.
             The format of ``instruction_durations`` must be as follows.
-            The instruction have to be a pair of instruction name and its acting physical qubits.
             The duration have to be a pair of duration (length) and its time unit.
             So it is usually a list of (instruction_name, qubits, duration, unit) tuples. E.g.
             | [('cx', [0, 1], 12.3, 'ns'), ('u3', [0], 4.56, 'ns')]

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -674,8 +674,7 @@ def _parse_instruction_durations(backend, instruction_durations, scheduling_meth
     if scheduling_method is not None:
         from qiskit.transpiler.instruction_durations import InstructionDurations
         if backend:
-            durations = InstructionDurations.from_backend(backend)
-            durations = durations.update(instruction_durations, unit='s')
+            durations = InstructionDurations.from_backend(backend).update(instruction_durations)
         else:
             durations = InstructionDurations(instruction_durations)
 

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -143,7 +143,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             | [('cx', [0, 1], 1000), ('u3', [0], 300)]
             If unit is omitted, the default is 'dt', which is a sample time depending on backend.
             If the time unit is 'dt', the duration must be an integer.
-        dt: Seconds of a unit 'dt', which is a sample time depending on backend.
+        dt: Backend sample time (resolution) in seconds.
             If ``None`` (default), ``backend.configuration().dt`` is used.
         seed_transpiler: Sets random seed for the stochastic parts of the transpiler
         optimization_level: How much optimization to perform on the circuits.

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -136,7 +136,6 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             The gate lengths defined in ``backend.properties`` are used as default and
             they are updated (overwritten) if this ``instruction_durations`` is specified.
             The format of ``instruction_durations`` must be as follows.
-            The duration have to be a pair of duration (length) and its time unit.
             So it is usually a list of (instruction_name, qubits, duration, unit) tuples. E.g.
             | [('cx', [0, 1], 12.3, 'ns'), ('u3', [0], 4.56, 'ns')]
             | [('cx', [0, 1], 1000), ('u3', [0], 300)]

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -136,7 +136,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             The gate lengths defined in ``backend.properties`` are used as default and
             they are updated (overwritten) if this ``instruction_durations`` is specified.
             The format of ``instruction_durations`` must be as follows.
-            So it is usually a list of (instruction_name, qubits, duration, unit) tuples. E.g.
+            The `instruction_durations` must be given as a list of tuples [(instruction_name, qubits, duration, unit), ...].
             | [('cx', [0, 1], 12.3, 'ns'), ('u3', [0], 4.56, 'ns')]
             | [('cx', [0, 1], 1000), ('u3', [0], 300)]
             If unit is omitted, the default is 'dt', which is a sample time depending on backend.

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -56,4 +56,5 @@ def circuit_to_dag(circuit):
         dagcircuit.apply_operation_back(instruction.copy(), qargs, cargs)
 
     dagcircuit.duration = circuit.duration
+    dagcircuit.unit = circuit.unit
     return dagcircuit

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -56,4 +56,5 @@ def dag_to_circuit(dag):
         circuit._append(inst, node.qargs, node.cargs)
 
     circuit.duration = dag.duration
+    circuit.unit = dag.unit
     return circuit

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -92,6 +92,7 @@ class DAGCircuit:
         self._global_phase = 0
 
         self.duration = None
+        self.unit = 'dt'
 
     def to_networkx(self):
         """Returns a copy of the DAGCircuit in networkx format."""

--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -47,6 +47,9 @@ class InstructionDurations:
 
         Returns:
             InstructionDurations: The InstructionDurations constructed from backend.
+
+        Raises:
+            TranspilerError: If dt and dtm is different in the backend.
         """
         # All durations in seconds in gate_length
         instruction_durations = []
@@ -64,6 +67,9 @@ class InstructionDurations:
         # TODO: backend.properties() should tell us durations of measurements
         # TODO: Remove the following lines after that
         try:
+            dtm = backend.configuration().dtm
+            if dtm != dt:
+                raise TranspilerError("dtm != dt case is not supported.")
             inst_map = backend.defaults().instruction_schedule_map
             all_qubits = tuple(range(backend.configuration().num_qubits))
             meas_duration = inst_map.get('measure', all_qubits).duration

--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -17,6 +17,8 @@ from qiskit.circuit import Barrier, Delay
 from qiskit.circuit import Instruction, Qubit
 from qiskit.providers import BaseBackend
 from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.util import apply_prefix
+from qiskit.circuit.duration import duration_in_dt
 
 
 class InstructionDurations:
@@ -24,88 +26,99 @@ class InstructionDurations:
 
     def __init__(self,
                  instruction_durations: Optional['InstructionDurationsType'] = None,
-                 unit: str = None):
+                 dt: float = None):
         self.duration_by_name = {}
         self.duration_by_name_qubits = {}
-        self.unit = unit
+        self.dt = dt  # pylint: disable=invalid-name
         if instruction_durations:
-            self.update(instruction_durations, unit)
+            self.update(instruction_durations)
 
     @classmethod
     def from_backend(cls, backend: BaseBackend):
         """Construct the instruction durations from the backend."""
+        # All durations in seconds in gate_length
         instruction_durations = []
-        # backend.properties._gates -> instruction_durations
         for gate, insts in backend.properties()._gates.items():
             for qubits, props in insts.items():
                 if 'gate_length' in props:
                     gate_length = props['gate_length'][0]  # Throw away datetime at index 1
-                    instruction_durations.append((gate, qubits, gate_length))
+                    instruction_durations.append((gate, qubits, gate_length, 's'))
 
-        # TODO: backend.properties() should tell us all about instruction durations
-        if not backend.configuration().open_pulse:
-            raise TranspilerError("No backend.configuration().dt in the backend")
-        # To know duration of measures, to be removed
-        dt = backend.configuration().dt  # pylint: disable=invalid-name
-        inst_map = backend.defaults().instruction_schedule_map
-        all_qubits = tuple(range(backend.configuration().num_qubits))
-        meas_duration = inst_map.get('measure', all_qubits).duration
-        for q in all_qubits:
-            instruction_durations.append(('measure', [q], meas_duration * dt))
+        try:
+            dt = backend.configuration().dt  # pylint: disable=invalid-name
+        except AttributeError:
+            dt = None
 
-        return InstructionDurations(instruction_durations, unit='s')
+        # TODO: backend.properties() should tell us durations of measurements
+        # TODO: Remove the following lines after that
+        try:
+            inst_map = backend.defaults().instruction_schedule_map
+            all_qubits = tuple(range(backend.configuration().num_qubits))
+            meas_duration = inst_map.get('measure', all_qubits).duration
+            for q in all_qubits:
+                instruction_durations.append(('measure', [q], meas_duration, 'dt'))
+        except AttributeError:
+            pass
+
+        return InstructionDurations(instruction_durations, dt=dt)
 
     def update(self,
-               inst_durations: Optional['InstructionDurationsType'],
-               unit: str = None):
+               inst_durations: Optional['InstructionDurationsType']):
         """Merge/extend self with instruction_durations."""
         if inst_durations is None:
             return self
-
-        if (not isinstance(inst_durations, InstructionDurations) and self.unit != unit) or \
-           (isinstance(inst_durations, InstructionDurations) and self.unit != inst_durations.unit):
-            raise TranspilerError("unit must be '%s', the same as original" % self.unit)
 
         if isinstance(inst_durations, InstructionDurations):
             self.duration_by_name.update(inst_durations.duration_by_name)
             self.duration_by_name_qubits.update(inst_durations.duration_by_name_qubits)
         else:
-            for name, qubits, duration in inst_durations:
+            for i, items in enumerate(inst_durations):
+                if len(items) == 4:
+                    pass
+                elif len(items) == 3:
+                    inst_durations[i] = (*items, 'dt')  # set default unit
+                else:
+                    raise TranspilerError("Each entry of inst_durations dictionary must be "
+                                          "(inst_name, qubits, duration) or "
+                                          "(inst_name, qubits, duration, unit)")
+
+            for name, qubits, duration, unit in inst_durations:
                 if isinstance(qubits, int):
                     qubits = [qubits]
 
                 if qubits is None:
-                    self.duration_by_name[name] = duration
+                    self.duration_by_name[name] = duration, unit
                 else:
-                    self.duration_by_name_qubits[(name, tuple(qubits))] = duration
+                    self.duration_by_name_qubits[(name, tuple(qubits))] = duration, unit
 
         return self
 
     def get(self,
-            inst_name: Union[str, Instruction],
-            qubits: Union[int, List[int], Qubit, List[Qubit]]) -> float:
+            inst: Union[str, Instruction],
+            qubits: Union[int, List[int], Qubit, List[Qubit]],
+            unit: str = 'dt') -> Union[float, int]:
         """Get the duration of the instruction with the name and the qubits.
 
         Args:
-            inst_name: an instruction or its name to be queried.
-            qubits: qubits or its indices that the instruction acts on.
+            inst: An instruction or its name to be queried.
+            qubits: Qubits or its indices that the instruction acts on.
+            unit: The unit of duration to be returned. It must be 's' or 'dt'.
 
         Returns:
-            float: The duration of the instruction on the qubits.
+            float|int: The duration of the instruction on the qubits.
 
         Raises:
             TranspilerError: No duration is defined for the instruction.
         """
-        if isinstance(inst_name, Barrier):
+        if isinstance(inst, Barrier):
             return 0
-        elif isinstance(inst_name, Delay):
-            if inst_name.unit != self.unit:
-                raise TranspilerError("unit of delay (currently %s) must be '%s', consistent "
-                                      "with other instructions" % (inst_name.unit, self.unit))
-            return inst_name.duration
+        elif isinstance(inst, Delay):
+            return self._convert_unit(inst.duration, inst.unit, unit)
 
-        if isinstance(inst_name, Instruction):
-            inst_name = inst_name.name
+        if isinstance(inst, Instruction):
+            inst_name = inst.name
+        else:
+            inst_name = inst
 
         if isinstance(qubits, (int, Qubit)):
             qubits = [qubits]
@@ -114,25 +127,48 @@ class InstructionDurations:
             qubits = [q.index for q in qubits]
 
         try:
-            return self._get(inst_name, qubits)
+            return self._get(inst_name, qubits, unit)
         except TranspilerError:
-            raise TranspilerError("Duration of %s on qubits %s is not found." % (inst_name, qubits))
+            raise TranspilerError("Duration of {} on qubits {} is not found."
+                                  .format(inst_name, qubits))
 
-    def _get(self, name: str, qubits: List[int]):
+    def _get(self, name: str, qubits: List[int], to_unit: str) -> Union[float ,int]:
         """Get the duration of the instruction with the name and the qubits."""
         if name == 'barrier':
             return 0
 
         key = (name, tuple(qubits))
         if key in self.duration_by_name_qubits:
-            return self.duration_by_name_qubits[key]
+            duration, unit = self.duration_by_name_qubits[key]
+        elif name in self.duration_by_name:
+            duration, unit = self.duration_by_name[name]
+        else:
+            raise TranspilerError("No value is found for key={}".format(key))
 
-        if name in self.duration_by_name:
-            return self.duration_by_name[name]
+        return self._convert_unit(duration, unit, to_unit)
 
-        raise TranspilerError("No value is found for key={}".format(key))
+    def _convert_unit(self, duration: float, from_unit: str, to_unit: str) -> Union[float ,int]:
+        if from_unit.endswith('s') and from_unit != 's':
+            duration = apply_prefix(duration, from_unit)
+            from_unit = 's'
+
+        # assert both from_unit and to_unit in {'s', 'dt'}
+        if from_unit == to_unit:
+            return duration
+
+        if self.dt is None:
+            raise TranspilerError("dt is necessary to convert durations from '{}' to '{}'"
+                                  .format(from_unit, to_unit))
+        if from_unit == 's' and to_unit == 'dt':
+            return duration_in_dt(duration, self.dt)
+        elif from_unit == 'dt' and to_unit == 's':
+            return duration * self.dt
+        else:
+            raise TranspilerError("Conversion from '{}' to '{}' is not supported"
+                                  .format(from_unit, to_unit))
 
 
 InstructionDurationsType = Union[List[Tuple[str, Optional[Iterable[int]], float]],
+                                 List[Tuple[str, Optional[Iterable[int]], float, str]],
                                  InstructionDurations]
 """List of tuples representing (instruction name, qubits indices, duration)."""

--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -89,11 +89,11 @@ class InstructionDurations:
         Raises:
             TranspilerError: If the format of instruction_durations is invalid.
         """
-        if inst_durations is None:
-            return self
-
         if dt:
             self.dt = dt
+
+        if inst_durations is None:
+            return self
 
         if isinstance(inst_durations, InstructionDurations):
             self.duration_by_name.update(inst_durations.duration_by_name)

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -177,6 +177,7 @@ from .synthesis import UnitarySynthesis
 # circuit scheduling
 from .scheduling import ALAPSchedule
 from .scheduling import ASAPSchedule
+from .scheduling import TimeUnitAnalysis
 
 # additional utility passes
 from .utils import CheckMap

--- a/qiskit/transpiler/passes/scheduling/__init__.py
+++ b/qiskit/transpiler/passes/scheduling/__init__.py
@@ -14,4 +14,5 @@
 
 from .alap import ALAPSchedule
 from .asap import ASAPSchedule
+from .time_unit_analysis import TimeUnitAnalysis
 from .remove_ops_on_idle_qubits import RemoveOpsOnIdleQubits

--- a/qiskit/transpiler/passes/scheduling/alap.py
+++ b/qiskit/transpiler/passes/scheduling/alap.py
@@ -29,11 +29,12 @@ class ALAPSchedule(TransformationPass):
         super().__init__()
         self._asap = ASAPSchedule(durations)
 
-    def run(self, dag):
+    def run(self, dag, time_unit=None):
         """Run the ALAPSchedule pass on `dag`.
 
         Args:
             dag (DAGCircuit): DAG to schedule.
+            time_unit (str): Time unit to be used in scheduling: 'dt' or 's'.
 
         Returns:
             DAGCircuit: A scheduled DAG.
@@ -44,8 +45,10 @@ class ALAPSchedule(TransformationPass):
         if len(dag.qregs) != 1 or dag.qregs.get('q', None) is None:
             raise TranspilerError('ALAP schedule runs on physical circuits only')
 
+        if not time_unit:
+            time_unit = self.property_set['time_unit']
         new_dag = dag.reverse_ops()
-        new_dag = self._asap.run(new_dag)
+        new_dag = self._asap.run(new_dag, self.property_set['time_unit'])
         new_dag = new_dag.reverse_ops()
 
         new_dag.name = dag.name

--- a/qiskit/transpiler/passes/scheduling/alap.py
+++ b/qiskit/transpiler/passes/scheduling/alap.py
@@ -47,8 +47,9 @@ class ALAPSchedule(TransformationPass):
 
         if not time_unit:
             time_unit = self.property_set['time_unit']
+
         new_dag = dag.reverse_ops()
-        new_dag = self._asap.run(new_dag, self.property_set['time_unit'])
+        new_dag = self._asap.run(new_dag, time_unit)
         new_dag = new_dag.reverse_ops()
 
         new_dag.name = dag.name

--- a/qiskit/transpiler/passes/scheduling/asap.py
+++ b/qiskit/transpiler/passes/scheduling/asap.py
@@ -86,4 +86,5 @@ class ASAPSchedule(TransformationPass):
 
         new_dag.name = dag.name
         new_dag.duration = circuit_duration
+        new_dag.unit = time_unit
         return new_dag

--- a/qiskit/transpiler/passes/scheduling/asap.py
+++ b/qiskit/transpiler/passes/scheduling/asap.py
@@ -73,6 +73,7 @@ class ASAPSchedule(TransformationPass):
             duration = self.durations.get(node.op, node.qargs, unit=time_unit)
             # set duration for each instruction (tricky but necessary)
             new_node.op.duration = duration
+            new_node.op.unit = time_unit
 
             stop_time = start_time + duration
             # update time table

--- a/qiskit/transpiler/passes/scheduling/time_unit_analysis.py
+++ b/qiskit/transpiler/passes/scheduling/time_unit_analysis.py
@@ -90,6 +90,7 @@ class TimeUnitAnalysis(AnalysisPass):
         for unit in unit_set:
             if not unit.endswith('s'):
                 all_si = False
+                break
 
         if all_si:
             return "SI"

--- a/qiskit/transpiler/passes/scheduling/time_unit_analysis.py
+++ b/qiskit/transpiler/passes/scheduling/time_unit_analysis.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2018.
+# (C) Copyright IBM 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,32 +11,30 @@
 # that they have been altered from the originals.
 
 """Choose a time unit to be used in the scheduling and its following passes."""
+from typing import Set
 
+from qiskit.circuit import Delay
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import AnalysisPass
-from qiskit.transpiler.instruction_durations import InstructionDurations
 from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.instruction_durations import InstructionDurations
 
 
 class TimeUnitAnalysis(AnalysisPass):
     """Choose a time unit to be used in the following passes
     (e.g. scheduling pass and dynamical decoupling pass).
-
     """
 
-    def __init__(self, inst_durations):
-        """TrivialLayout initializer.
+    def __init__(self, inst_durations: InstructionDurations):
+        """TimeUnitAnalysis initializer.
 
         Args:
-            inst_durations (InstructionDurations): TO BE FILLED.
-            dt (float): TO BE FILLED.
-
-        Raises:
-            TranspilerError: if invalid options
+            inst_durations (InstructionDurations): A dictionary of durations of instructions.
         """
         super().__init__()
-        self.durations = inst_durations
+        self.inst_durations = inst_durations
 
-    def run(self, dag):
+    def run(self, dag: DAGCircuit):
         """Run the TimeUnitAnalysis pass on `dag`.
 
         Args:
@@ -45,5 +43,49 @@ class TimeUnitAnalysis(AnalysisPass):
         Raises:
             TranspilerError: if the units are not unifiable
         """
-        # TODO: implement!
-        self.property_set['time_unit'] = 'dt'  # mock implementation
+        if self.inst_durations.dt is not None:
+            self.property_set['time_unit'] = 'dt'
+        else:
+            # Check what units are used in delays and other instructions: dt or SI or mixed
+            units_delay = self._units_used_in_delays(dag)
+            if self._unified(units_delay) == "mixed":
+                raise TranspilerError("Fail to unify time units in delays. SI units "
+                                      "and dt unit must not be mixed when dt is not supplied.")
+            units_other = self.inst_durations.units_used()
+            if self._unified(units_other) == "mixed":
+                raise TranspilerError("Fail to unify time units in instruction_durations. SI units "
+                                      "and dt unit must not be mixed when dt is not supplied.")
+
+            unified_unit = self._unified(units_delay | units_other)
+            if unified_unit == "SI":
+                self.property_set['time_unit'] = 's'
+            elif unified_unit == "dt":
+                self.property_set['time_unit'] = 'dt'
+            else:
+                raise TranspilerError("Fail to unify time units. SI units "
+                                      "and dt unit must not be mixed when dt is not supplied.")
+
+    @staticmethod
+    def _units_used_in_delays(dag: DAGCircuit) -> Set[str]:
+        units_used = set()
+        for node in dag.op_nodes(op=Delay):
+            units_used.add(node.op.unit)
+        return units_used
+
+    @staticmethod
+    def _unified(unit_set: Set[str]) -> str:
+        if not unit_set:
+            return "dt"
+
+        if len(unit_set) == 1 and 'dt' in unit_set:
+            return "dt"
+
+        all_si = True
+        for unit in unit_set:
+            if not unit.endswith('s'):
+                all_si = False
+
+        if all_si:
+            return "SI"
+
+        return "mixed"

--- a/qiskit/transpiler/passes/scheduling/time_unit_analysis.py
+++ b/qiskit/transpiler/passes/scheduling/time_unit_analysis.py
@@ -23,6 +23,12 @@ from qiskit.transpiler.instruction_durations import InstructionDurations
 class TimeUnitAnalysis(AnalysisPass):
     """Choose a time unit to be used in the following passes
     (e.g. scheduling pass and dynamical decoupling pass).
+
+    If dt (dt in seconds) is known to transpiler, the unit 'dt' is chosen. Otherwise,
+    the unit to be selected depends on what units are used in delays and instruction durations:
+    * 's': if they are all in SI units.
+    * 'dt': if they are all in the unit 'dt'.
+    * raise error: if they are a mix of SI units and 'dt'.
     """
 
     def __init__(self, inst_durations: InstructionDurations):

--- a/qiskit/transpiler/passes/scheduling/time_unit_analysis.py
+++ b/qiskit/transpiler/passes/scheduling/time_unit_analysis.py
@@ -1,0 +1,49 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Choose a time unit to be used in the scheduling and its following passes."""
+
+from qiskit.transpiler.basepasses import AnalysisPass
+from qiskit.transpiler.instruction_durations import InstructionDurations
+from qiskit.transpiler.exceptions import TranspilerError
+
+
+class TimeUnitAnalysis(AnalysisPass):
+    """Choose a time unit to be used in the following passes
+    (e.g. scheduling pass and dynamical decoupling pass).
+
+    """
+
+    def __init__(self, inst_durations):
+        """TrivialLayout initializer.
+
+        Args:
+            inst_durations (InstructionDurations): TO BE FILLED.
+            dt (float): TO BE FILLED.
+
+        Raises:
+            TranspilerError: if invalid options
+        """
+        super().__init__()
+        self.durations = inst_durations
+
+    def run(self, dag):
+        """Run the TimeUnitAnalysis pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): DAG to be checked.
+
+        Raises:
+            TranspilerError: if the units are not unifiable
+        """
+        # TODO: implement!
+        self.property_set['time_unit'] = 'dt'  # mock implementation

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -41,6 +41,9 @@ from qiskit.transpiler.passes import CheckCXDirection
 from qiskit.transpiler.passes import Collect2qBlocks
 from qiskit.transpiler.passes import ConsolidateBlocks
 from qiskit.transpiler.passes import UnitarySynthesis
+from qiskit.transpiler.passes import TimeUnitAnalysis
+from qiskit.transpiler.passes import ALAPSchedule
+from qiskit.transpiler.passes import ASAPSchedule
 
 from qiskit.transpiler import TranspilerError
 
@@ -147,13 +150,10 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     # 7. Schedule the circuit only when scheduling_method is supplied
     if scheduling_method:
-        from qiskit.transpiler.passes import TimeUnitAnalysis
         _scheduling = [TimeUnitAnalysis(instruction_durations)]
         if scheduling_method in {'alap', 'as_late_as_possible'}:
-            from qiskit.transpiler.passes import ALAPSchedule
             _scheduling += [ALAPSchedule(instruction_durations)]
         elif scheduling_method in {'asap', 'as_soon_as_possible'}:
-            from qiskit.transpiler.passes import ASAPSchedule
             _scheduling += [ASAPSchedule(instruction_durations)]
         else:
             raise TranspilerError("Invalid scheduling method %s." % scheduling_method)

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -147,7 +147,8 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     # 7. Schedule the circuit only when scheduling_method is supplied
     if scheduling_method:
-        _scheduling = []
+        from qiskit.transpiler.passes import TimeUnitAnalysis
+        _scheduling = [TimeUnitAnalysis(instruction_durations)]
         if scheduling_method in {'alap', 'as_late_as_possible'}:
             from qiskit.transpiler.passes import ALAPSchedule
             _scheduling += [ALAPSchedule(instruction_durations)]

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -47,6 +47,9 @@ from qiskit.transpiler.passes import Layout2qDistance
 from qiskit.transpiler.passes import Collect2qBlocks
 from qiskit.transpiler.passes import ConsolidateBlocks
 from qiskit.transpiler.passes import UnitarySynthesis
+from qiskit.transpiler.passes import TimeUnitAnalysis
+from qiskit.transpiler.passes import ALAPSchedule
+from qiskit.transpiler.passes import ASAPSchedule
 
 from qiskit.transpiler import TranspilerError
 
@@ -175,13 +178,10 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     # 10. Schedule the circuit only when scheduling_method is supplied
     if scheduling_method:
-        from qiskit.transpiler.passes import TimeUnitAnalysis
         _scheduling = [TimeUnitAnalysis(instruction_durations)]
         if scheduling_method in {'alap', 'as_late_as_possible'}:
-            from qiskit.transpiler.passes import ALAPSchedule
             _scheduling += [ALAPSchedule(instruction_durations)]
         elif scheduling_method in {'asap', 'as_soon_as_possible'}:
-            from qiskit.transpiler.passes import ASAPSchedule
             _scheduling += [ASAPSchedule(instruction_durations)]
         else:
             raise TranspilerError("Invalid scheduling method %s." % scheduling_method)

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -175,7 +175,8 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     # 10. Schedule the circuit only when scheduling_method is supplied
     if scheduling_method:
-        _scheduling = []
+        from qiskit.transpiler.passes import TimeUnitAnalysis
+        _scheduling = [TimeUnitAnalysis(instruction_durations)]
         if scheduling_method in {'alap', 'as_late_as_possible'}:
             from qiskit.transpiler.passes import ALAPSchedule
             _scheduling += [ALAPSchedule(instruction_durations)]

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -170,7 +170,8 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     # 9. Schedule the circuit only when scheduling_method is supplied
     if scheduling_method:
-        _scheduling = []
+        from qiskit.transpiler.passes import TimeUnitAnalysis
+        _scheduling = [TimeUnitAnalysis(instruction_durations)]
         if scheduling_method in {'alap', 'as_late_as_possible'}:
             from qiskit.transpiler.passes import ALAPSchedule
             _scheduling += [ALAPSchedule(instruction_durations)]

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -48,6 +48,9 @@ from qiskit.transpiler.passes import CheckCXDirection
 from qiskit.transpiler.passes import Collect2qBlocks
 from qiskit.transpiler.passes import ConsolidateBlocks
 from qiskit.transpiler.passes import UnitarySynthesis
+from qiskit.transpiler.passes import TimeUnitAnalysis
+from qiskit.transpiler.passes import ALAPSchedule
+from qiskit.transpiler.passes import ASAPSchedule
 
 from qiskit.transpiler import TranspilerError
 
@@ -170,13 +173,10 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     # 9. Schedule the circuit only when scheduling_method is supplied
     if scheduling_method:
-        from qiskit.transpiler.passes import TimeUnitAnalysis
         _scheduling = [TimeUnitAnalysis(instruction_durations)]
         if scheduling_method in {'alap', 'as_late_as_possible'}:
-            from qiskit.transpiler.passes import ALAPSchedule
             _scheduling += [ALAPSchedule(instruction_durations)]
         elif scheduling_method in {'asap', 'as_soon_as_possible'}:
-            from qiskit.transpiler.passes import ASAPSchedule
             _scheduling += [ASAPSchedule(instruction_durations)]
         else:
             raise TranspilerError("Invalid scheduling method %s." % scheduling_method)

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -51,6 +51,9 @@ from qiskit.transpiler.passes import ConsolidateBlocks
 from qiskit.transpiler.passes import UnitarySynthesis
 from qiskit.transpiler.passes import ApplyLayout
 from qiskit.transpiler.passes import CheckCXDirection
+from qiskit.transpiler.passes import TimeUnitAnalysis
+from qiskit.transpiler.passes import ALAPSchedule
+from qiskit.transpiler.passes import ASAPSchedule
 
 from qiskit.transpiler import TranspilerError
 
@@ -181,13 +184,10 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     # Schedule the circuit only when scheduling_method is supplied
     if scheduling_method:
-        from qiskit.transpiler.passes import TimeUnitAnalysis
         _scheduling = [TimeUnitAnalysis(instruction_durations)]
         if scheduling_method in {'alap', 'as_late_as_possible'}:
-            from qiskit.transpiler.passes import ALAPSchedule
             _scheduling += [ALAPSchedule(instruction_durations)]
         elif scheduling_method in {'asap', 'as_soon_as_possible'}:
-            from qiskit.transpiler.passes import ASAPSchedule
             _scheduling += [ASAPSchedule(instruction_durations)]
         else:
             raise TranspilerError("Invalid scheduling method %s." % scheduling_method)

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -181,7 +181,8 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     # Schedule the circuit only when scheduling_method is supplied
     if scheduling_method:
-        _scheduling = []
+        from qiskit.transpiler.passes import TimeUnitAnalysis
+        _scheduling = [TimeUnitAnalysis(instruction_durations)]
         if scheduling_method in {'alap', 'as_late_as_possible'}:
             from qiskit.transpiler.passes import ALAPSchedule
             _scheduling += [ALAPSchedule(instruction_durations)]

--- a/test/python/circuit/test_delay.py
+++ b/test/python/circuit/test_delay.py
@@ -17,11 +17,29 @@
 import numpy as np
 from qiskit.circuit import Delay
 from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.exceptions import CircuitError
 from qiskit.test.base import QiskitTestCase
 
 
 class TestDelayClass(QiskitTestCase):
     """Test delay instruction for quantum circuits."""
+
+    def test_keep_units_after_adding_delays_to_circuit(self):
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        qc.delay(100, 0)
+        qc.delay(200, 0, unit='s')
+        qc.delay(300, 0, unit='ns')
+        qc.delay(400, 0, unit='dt')
+        self.assertEqual(qc.data[1][0].unit, None)
+        self.assertEqual(qc.data[2][0].unit, 's')
+        self.assertEqual(qc.data[3][0].unit, 'ns')
+        self.assertEqual(qc.data[4][0].unit, 'dt')
+
+    def test_fail_if_unknown_unit_is_supplied(self):
+        qc = QuantumCircuit(1)
+        with self.assertRaises(CircuitError):
+            qc.delay(100, 0, unit='my_unit')
 
     def test_add_delay_on_single_qubit_to_circuit(self):
         qc = QuantumCircuit(1)

--- a/test/python/circuit/test_delay.py
+++ b/test/python/circuit/test_delay.py
@@ -31,7 +31,7 @@ class TestDelayClass(QiskitTestCase):
         qc.delay(200, 0, unit='s')
         qc.delay(300, 0, unit='ns')
         qc.delay(400, 0, unit='dt')
-        self.assertEqual(qc.data[1][0].unit, None)
+        self.assertEqual(qc.data[1][0].unit, 'dt')
         self.assertEqual(qc.data[2][0].unit, 's')
         self.assertEqual(qc.data[3][0].unit, 'ns')
         self.assertEqual(qc.data[4][0].unit, 'dt')

--- a/test/python/circuit/test_delay.py
+++ b/test/python/circuit/test_delay.py
@@ -36,6 +36,11 @@ class TestDelayClass(QiskitTestCase):
         self.assertEqual(qc.data[3][0].unit, 'ns')
         self.assertEqual(qc.data[4][0].unit, 'dt')
 
+    def test_fail_if_non_integer_duration_with_dt_unit_is_supplied(self):
+        qc = QuantumCircuit(1)
+        with self.assertRaises(CircuitError):
+            qc.delay(0.5, 0, unit='dt')
+
     def test_fail_if_unknown_unit_is_supplied(self):
         qc = QuantumCircuit(1)
         with self.assertRaises(CircuitError):

--- a/test/python/circuit/test_scheduled_circuit.py
+++ b/test/python/circuit/test_scheduled_circuit.py
@@ -36,9 +36,11 @@ class TestScheduledCircuit(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.delay(0.1, 0, unit='ms')  # 450000[dt]
         qc.delay(100, 0, unit='ns')  # 450[dt]
-        qc.h(0)
-        qc.h(1)
+        qc.h(0)  # 160[dt]
+        qc.h(1)  # 160[dt]
         sc = transpile(qc, self.backend_with_dt, scheduling_method='alap')
+        self.assertEqual(sc.duration, 450610)
+        self.assertEqual(sc.unit, 'dt')
         self.assertEqual(sc.data[1][0].name, "delay")
         self.assertEqual(sc.data[1][0].duration, 450)
         self.assertEqual(sc.data[1][0].unit, 'dt')
@@ -62,6 +64,8 @@ class TestScheduledCircuit(QiskitTestCase):
         qc.h(0)
         qc.h(1)
         sc = transpile(qc, self.backend_without_dt, scheduling_method='alap', dt=self.dt)
+        self.assertEqual(sc.duration, 450610)
+        self.assertEqual(sc.unit, 'dt')
         self.assertEqual(sc.data[1][0].name, "delay")
         self.assertEqual(sc.data[1][0].duration, 450)
         self.assertEqual(sc.data[1][0].unit, 'dt')
@@ -80,6 +84,8 @@ class TestScheduledCircuit(QiskitTestCase):
         qc.h(0)
         qc.h(1)
         sc = transpile(qc, self.backend_without_dt, scheduling_method='alap')
+        self.assertAlmostEqual(sc.duration, 450610*self.dt)
+        self.assertEqual(sc.unit, 's')
         self.assertEqual(sc.data[1][0].name, "delay")
         self.assertAlmostEqual(sc.data[1][0].duration, 1.0e-7)
         self.assertEqual(sc.data[1][0].unit, 's')

--- a/test/python/circuit/test_scheduled_circuit.py
+++ b/test/python/circuit/test_scheduled_circuit.py
@@ -16,7 +16,6 @@
 
 from qiskit import QuantumCircuit, QiskitError
 from qiskit import transpile, execute, assemble
-from qiskit.circuit.duration import duration_in_dt
 from qiskit.test.mock.backends import FakeParis, FakeVigo
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.instruction_durations import InstructionDurations
@@ -28,43 +27,73 @@ class TestScheduledCircuit(QiskitTestCase):
     """Test scheduled circuit (quantum circuit with duration)."""
     def setUp(self):
         super().setUp()
-        self.backend = FakeParis()
-        self.dt = self.backend.configuration().dt
         self.backend_with_dt = FakeParis()
         self.backend_without_dt = FakeVigo()
+        self.dt = 2.2222222222222221e-10
 
-    def test_scinario_1_with_backend(self):
-        """[Scenario 1: dt is known to transpiler]"""
+    def test_schedule_circuit_when_backend_tells_dt(self):
+        """dt is known to transpiler by backend"""
         qc = QuantumCircuit(2)
-        qc.delay(0.1, 0, unit='ms')
-        qc.delay(100, 0, unit='ns')
+        qc.delay(0.1, 0, unit='ms')  # 450000[dt]
+        qc.delay(100, 0, unit='ns')  # 450[dt]
         qc.h(0)
         qc.h(1)
         sc = transpile(qc, self.backend_with_dt, scheduling_method='alap')
+        self.assertEqual(sc.data[1][0].name, "delay")
+        self.assertEqual(sc.data[1][0].duration, 450)
+        self.assertEqual(sc.data[1][0].unit, 'dt')
+        self.assertEqual(sc.data[2][0].name, "u2")
+        self.assertEqual(sc.data[2][0].duration, 160)
+        self.assertEqual(sc.data[2][0].unit, 'dt')
+        self.assertEqual(sc.data[3][0].name, "delay")
+        self.assertEqual(sc.data[3][0].duration, 450450)
+        self.assertEqual(sc.data[3][0].unit, 'dt')
         qobj = assemble(sc, self.backend_with_dt)
+        self.assertEqual(qobj.experiments[0].instructions[1].name, "delay")
+        self.assertEqual(qobj.experiments[0].instructions[1].params[0], 450)
+        self.assertEqual(qobj.experiments[0].instructions[3].name, "delay")
+        self.assertEqual(qobj.experiments[0].instructions[3].params[0], 450450)
 
-    def test_scinario_1_without_backend(self):
+    def test_schedule_circuit_when_transpile_option_tells_dt(self):
+        """dt is known to transpiler by transpile option"""
         qc = QuantumCircuit(2)
-        qc.delay(0.1, 0, unit='ms')
-        qc.delay(100, 0, unit='ns')
+        qc.delay(0.1, 0, unit='ms')  # 450000[dt]
+        qc.delay(100, 0, unit='ns')  # 450[dt]
         qc.h(0)
         qc.h(1)
-        sc = transpile(qc, scheduling_method='alap', instruction_durations=[('h', None, 50)],
-                       dt=0.123)
+        sc = transpile(qc, self.backend_without_dt, scheduling_method='alap', dt=self.dt)
+        self.assertEqual(sc.data[1][0].name, "delay")
+        self.assertEqual(sc.data[1][0].duration, 450)
+        self.assertEqual(sc.data[1][0].unit, 'dt')
+        self.assertEqual(sc.data[2][0].name, "u2")
+        self.assertEqual(sc.data[2][0].duration, 160)
+        self.assertEqual(sc.data[2][0].unit, 'dt')
+        self.assertEqual(sc.data[3][0].name, "delay")
+        self.assertEqual(sc.data[3][0].duration, 450450)
+        self.assertEqual(sc.data[3][0].unit, 'dt')
 
-    def test_scinario_2_with_backend(self):
-        """[Scenario 2: dt is unknown and all delays and gate times are in SI]"""
+    def test_schedule_circuit_in_sec_when_no_one_tells_dt(self):
+        """dt is unknown and all delays and gate times are in SI"""
         qc = QuantumCircuit(2)
         qc.delay(0.1, 0, unit='ms')
         qc.delay(100, 0, unit='ns')
         qc.h(0)
         qc.h(1)
         sc = transpile(qc, self.backend_without_dt, scheduling_method='alap')
+        self.assertEqual(sc.data[1][0].name, "delay")
+        self.assertAlmostEqual(sc.data[1][0].duration, 1.0e-7)
+        self.assertEqual(sc.data[1][0].unit, 's')
+        self.assertEqual(sc.data[2][0].name, "u2")
+        self.assertAlmostEqual(sc.data[2][0].duration, 160*self.dt)
+        self.assertEqual(sc.data[2][0].unit, 's')
+        self.assertEqual(sc.data[3][0].name, "delay")
+        self.assertAlmostEqual(sc.data[3][0].duration, 1.0e-4+1.0e-7)
+        self.assertEqual(sc.data[3][0].unit, 's')
         with self.assertRaises(QiskitError):
             assemble(sc, self.backend_without_dt)
 
-    def test_scinario_3_with_backend(self):
-        """[Scenario 3: dt is unknown but delays and gate times have a mix of SI and dt]"""
+    def test_cannot_schedule_circuit_with_mixed_SI_and_dt_when_no_one_tells_dt(self):
+        """dt is unknown but delays and gate times have a mix of SI and dt"""
         qc = QuantumCircuit(2)
         qc.delay(100, 0, unit='ns')
         qc.delay(30, 0, unit='dt')
@@ -79,14 +108,14 @@ class TestScheduledCircuit(QiskitTestCase):
         qc.delay(500, 1)
         qc.cx(0, 1)
         with self.assertRaises(QiskitError):
-            execute(qc, backend=self.backend, schedule_circuit=False)
+            execute(qc, backend=self.backend_with_dt, schedule_circuit=False)
 
     def test_transpile_t1_circuit(self):
         qc = QuantumCircuit(1)
         qc.x(0)  # 320 [dt]
         qc.delay(1000, 0, unit='ns')  # 4500 [dt]
         qc.measure_all()  # 19200 [dt]
-        scheduled = transpile(qc, backend=self.backend, scheduling_method='alap')
+        scheduled = transpile(qc, backend=self.backend_with_dt, scheduling_method='alap')
         self.assertEqual(scheduled.duration, 24020)
 
     def test_transpile_delay_circuit_with_backend(self):
@@ -94,7 +123,7 @@ class TestScheduledCircuit(QiskitTestCase):
         qc.h(0)
         qc.delay(100, 1, unit='ns')  # 450 [dt]
         qc.cx(0, 1)  # 1408 [dt]
-        scheduled = transpile(qc, backend=self.backend, scheduling_method='alap')
+        scheduled = transpile(qc, backend=self.backend_with_dt, scheduling_method='alap')
         self.assertEqual(scheduled.duration, 1858)
 
     def test_transpile_delay_circuit_without_backend(self):
@@ -129,7 +158,7 @@ class TestScheduledCircuit(QiskitTestCase):
         qc.delay(500*self.dt, 1, 's')
         qc.cx(0, 1)
         scheduled = transpile(qc,
-                              backend=self.backend,
+                              backend=self.backend_with_dt,
                               scheduling_method='alap')
         # append a gate to a scheduled circuit
         scheduled.h(0)
@@ -165,14 +194,14 @@ class TestScheduledCircuit(QiskitTestCase):
         qc.cx(0, 1)
         # usual case
         scheduled = transpile(qc,
-                              backend=self.backend,
+                              backend=self.backend_with_dt,
                               scheduling_method='alap'
                               )
         self.assertEqual(scheduled.duration, 1908)
 
         # update durations
         scheduled = transpile(qc,
-                              backend=self.backend,
+                              backend=self.backend_with_dt,
                               scheduling_method='alap',
                               instruction_durations=[('cx', [0, 1], 1000*self.dt, 's')]
                               )
@@ -180,7 +209,7 @@ class TestScheduledCircuit(QiskitTestCase):
 
         my_own_durations = InstructionDurations([('cx', [0, 1], 1000*self.dt, 's')])
         scheduled = transpile(qc,
-                              backend=self.backend,  # unit='s'
+                              backend=self.backend_with_dt,  # unit='s'
                               scheduling_method='alap',
                               instruction_durations=my_own_durations
                               )

--- a/test/python/transpiler/test_instruction_durations.py
+++ b/test/python/transpiler/test_instruction_durations.py
@@ -1,0 +1,48 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-function-docstring
+
+"""Test InstructionDurations class."""
+
+from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.instruction_durations import InstructionDurations
+
+from qiskit.test.base import QiskitTestCase
+from qiskit.test.mock.backends import FakeParis, FakeVigo
+
+
+class TestInstructionDurationsClass(QiskitTestCase):
+    """Test Test InstructionDurations class."""
+
+    def test_empty(self):
+        durations = InstructionDurations()
+        self.assertEqual(durations.dt, None)
+        with self.assertRaises(TranspilerError):
+            durations.get('cx', [0, 1], 'dt')
+
+    def test_fail_if_invalid_dict_is_supplied_when_construction(self):
+        invalid_dic = [('cx', [0, 1])]  # no duration
+        with self.assertRaises(TranspilerError):
+            InstructionDurations(invalid_dic)
+
+    def test_from_backend_for_backend_with_dt(self):
+        durations = InstructionDurations.from_backend(FakeParis())
+        self.assertGreater(durations.dt, 0)
+        self.assertGreater(durations.get('u2', 0), 0)
+
+    def test_from_backend_for_backend_without_dt(self):
+        durations = InstructionDurations.from_backend(FakeVigo())
+        self.assertIsNone(durations.dt)
+        self.assertGreater(durations.get('u2', 0, 's'), 0)
+        with self.assertRaises(TranspilerError):
+            durations.get('u2', 0)


### PR DESCRIPTION
### Summary
This PR improves handling of durations with time unit. Transpiler will check units (and convert if necessary) every time it looks up an instruction to be scheduled. A scheduled circuit and its instructions will have duration with unit.  

### Details and comments
- Add unit property to Instruction and QuantumCircuit
- Add a new argument dt=None to transpile
- Add TimeUnitAnalysis pass to check which unit to be used in the following passes
- Change scheduling passes to use property_set['time_unit']
- Change to keep unit of delays until transpiling
- Improve InstructionDurations to convert unit of delays on demand 
- Change default unit of delays from None to dt
- Add validation to force integer duration if unit is 'dt'
- Fix to check if time unit of duration is 'dt' in assemble