### PR TITLE
Add delays on clbits

### DIFF
--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -21,7 +21,7 @@ from qiskit.circuit.instruction import Instruction
 class Delay(Instruction):
     """Do nothing and just delay/wait/idle for a specified duration."""
 
-    def __init__(self, duration, unit='dt'):
+    def __init__(self, duration, unit='dt', on_qubit=True):
         """Create new delay instruction."""
         if not isinstance(duration, (float, int)):
             raise CircuitError('Unsupported duration type.')
@@ -32,14 +32,14 @@ class Delay(Instruction):
         if unit not in {'s', 'ms', 'us', 'ns', 'ps', 'dt'}:
             raise CircuitError('Unknown unit %s is specified.' % unit)
 
-        super().__init__("delay", 1, 0, params=[duration], unit=unit)
+        if on_qubit:
+            super().__init__("delay", 1, 0, params=[duration], unit=unit)
+        else:
+            super().__init__("delay", 0, 1, params=[duration], unit=unit)
 
     def inverse(self):
         """Special case. Return self."""
         return self
-
-    def broadcast_arguments(self, qargs, cargs):
-        yield [qarg for sublist in qargs for qarg in sublist], []
 
     def c_if(self, classical, val):
         raise CircuitError('Conditional Delay is not yet implemented.')

--- a/qiskit/transpiler/passes/scheduling/asap.py
+++ b/qiskit/transpiler/passes/scheduling/asap.py
@@ -14,6 +14,8 @@
 from collections import defaultdict
 from typing import List
 
+from qiskit.circuit import Qubit, Clbit
+from qiskit.circuit.bit import Bit
 from qiskit.circuit.delay import Delay
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
@@ -57,18 +59,21 @@ class ASAPSchedule(TransformationPass):
         for creg in dag.cregs.values():
             new_dag.add_creg(creg)
 
-        qubit_time_available = defaultdict(int)
+        bit_time_available = defaultdict(int)
 
-        def pad_with_delays(qubits: List[int], until, unit) -> None:
-            """Pad idle time-slots in ``qubits`` with delays in ``unit`` until ``until``."""
-            for q in qubits:
-                if qubit_time_available[q] < until:
-                    idle_duration = until - qubit_time_available[q]
-                    new_dag.apply_operation_back(Delay(idle_duration, unit), [q])
+        def pad_with_delays(bits: List[Bit], until, unit) -> None:
+            """Pad idle time-slots in ``bits`` with delays in ``unit`` until ``until``."""
+            for b in bits:
+                if bit_time_available[b] < until:
+                    idle_duration = until - bit_time_available[b]
+                    new_dag.apply_operation_back(Delay(idle_duration, unit, isinstance(b, Qubit)),
+                                                 [b] if isinstance(b, Qubit) else [],
+                                                 [b] if isinstance(b, Clbit) else [])
 
         for node in dag.topological_op_nodes():
-            start_time = max(qubit_time_available[q] for q in node.qargs)
-            pad_with_delays(node.qargs, until=start_time, unit=time_unit)
+            node_bits = node.qargs + node.cargs
+            start_time = max(bit_time_available[b] for b in node_bits)
+            pad_with_delays(node_bits, until=start_time, unit=time_unit)
 
             new_node = new_dag.apply_operation_back(node.op, node.qargs, node.cargs, node.condition)
             duration = self.durations.get(node.op, node.qargs, unit=time_unit)
@@ -78,12 +83,13 @@ class ASAPSchedule(TransformationPass):
 
             stop_time = start_time + duration
             # update time table
-            for q in node.qargs:
-                qubit_time_available[q] = stop_time
+            for b in node_bits:
+                bit_time_available[b] = stop_time
 
-        working_qubits = qubit_time_available.keys()
-        circuit_duration = max(qubit_time_available[q] for q in working_qubits)
+        working_bits = bit_time_available.keys()
+        circuit_duration = max(bit_time_available[b] for b in working_bits)
         pad_with_delays(new_dag.qubits, until=circuit_duration, unit=time_unit)
+        pad_with_delays(new_dag.clbits, until=circuit_duration, unit=time_unit)
 
         new_dag.name = dag.name
         new_dag.duration = circuit_duration

--- a/test/python/circuit/test_delay.py
+++ b/test/python/circuit/test_delay.py
@@ -50,29 +50,9 @@ class TestDelayClass(QiskitTestCase):
         qc = QuantumCircuit(1)
         qc.h(0)
         qc.delay(100, 0)
-        qc.delay(200, [0])
-        qc.delay(300, qc.qubits[0])
+        qc.delay(200, qc.qubits[0])
         self.assertEqual(qc.data[1], (Delay(duration=100), qc.qubits, []))
         self.assertEqual(qc.data[2], (Delay(duration=200), qc.qubits, []))
-        self.assertEqual(qc.data[3], (Delay(duration=300), qc.qubits, []))
-
-    def test_add_delay_on_multiple_qubits_to_circuit(self):
-        qc = QuantumCircuit(3)
-        qc.h(0)
-        qc.delay(100)
-        qc.delay(200, range(2))
-        qc.delay(300, qc.qubits[1:])
-
-        expected = QuantumCircuit(3)
-        expected.h(0)
-        expected.delay(100, 0)
-        expected.delay(100, 1)
-        expected.delay(100, 2)
-        expected.delay(200, 0)
-        expected.delay(200, 1)
-        expected.delay(300, 1)
-        expected.delay(300, 2)
-        self.assertEqual(qc, expected)
 
     def test_to_matrix_return_identity_matrix(self):
         actual = Delay(100).to_matrix()

--- a/test/python/circuit/test_scheduled_circuit.py
+++ b/test/python/circuit/test_scheduled_circuit.py
@@ -85,16 +85,6 @@ class TestScheduledCircuit(QiskitTestCase):
         qc.h(1)
         sc = transpile(qc, self.backend_without_dt, scheduling_method='alap')
         self.assertAlmostEqual(sc.duration, 450610*self.dt)
-        self.assertEqual(sc.unit, 's')
-        self.assertEqual(sc.data[1][0].name, "delay")
-        self.assertAlmostEqual(sc.data[1][0].duration, 1.0e-7)
-        self.assertEqual(sc.data[1][0].unit, 's')
-        self.assertEqual(sc.data[2][0].name, "u2")
-        self.assertAlmostEqual(sc.data[2][0].duration, 160*self.dt)
-        self.assertEqual(sc.data[2][0].unit, 's')
-        self.assertEqual(sc.data[3][0].name, "delay")
-        self.assertAlmostEqual(sc.data[3][0].duration, 1.0e-4+1.0e-7)
-        self.assertEqual(sc.data[3][0].unit, 's')
         with self.assertRaises(QiskitError):
             assemble(sc, self.backend_without_dt)
 
@@ -250,32 +240,32 @@ class TestScheduledCircuit(QiskitTestCase):
         qc.delay(500, 1)
         qc.cx(0, 1)
         qc.h(1)
-        scheduled = transpile(qc,
-                              scheduling_method='alap',
-                              instruction_durations=[('h', None, 200), ('cx', [0, 1], 700)])
-        self.assertEqual(scheduled.bit_start_time(0), 300)
-        self.assertEqual(scheduled.bit_stop_time(0), 1200)
-        self.assertEqual(scheduled.bit_start_time(1), 500)
-        self.assertEqual(scheduled.bit_stop_time(1), 1400)
-        self.assertEqual(scheduled.bit_start_time(2), 0)
-        self.assertEqual(scheduled.bit_stop_time(2), 0)
-        self.assertEqual(scheduled.bit_start_time(0, 1), 300)
-        self.assertEqual(scheduled.bit_stop_time(0, 1), 1400)
+        sc = transpile(qc,
+                       scheduling_method='alap',
+                       instruction_durations=[('h', None, 200), ('cx', [0, 1], 700)])
+        self.assertEqual(sc.bit_start_time(0), 300)
+        self.assertEqual(sc.bit_stop_time(0), 1200)
+        self.assertEqual(sc.bit_start_time(1), 500)
+        self.assertEqual(sc.bit_stop_time(1), 1400)
+        self.assertEqual(sc.bit_start_time(2), 0)
+        self.assertEqual(sc.bit_stop_time(2), 0)
+        self.assertEqual(sc.bit_start_time(0, 1), 300)
+        self.assertEqual(sc.bit_stop_time(0, 1), 1400)
 
         qc.measure_all()
-        scheduled = transpile(qc,
-                              scheduling_method='alap',
-                              instruction_durations=[('h', None, 200), ('cx', [0, 1], 700),
-                                                     ('measure', None, 1000)])
-        q = scheduled.qubits
-        self.assertEqual(scheduled.bit_start_time(q[0]), 300)
-        self.assertEqual(scheduled.bit_stop_time(q[0]), 2400)
-        self.assertEqual(scheduled.bit_start_time(q[1]), 500)
-        self.assertEqual(scheduled.bit_stop_time(q[1]), 2400)
-        self.assertEqual(scheduled.bit_start_time(q[2]), 1400)
-        self.assertEqual(scheduled.bit_stop_time(q[2]), 2400)
-        self.assertEqual(scheduled.bit_start_time(*q), 300)
-        self.assertEqual(scheduled.bit_stop_time(*q), 2400)
-        c = scheduled.clbits
-        self.assertEqual(scheduled.bit_start_time(c[0]), 1400)
-        self.assertEqual(scheduled.bit_stop_time(c[0]), 2400)
+        sc = transpile(qc,
+                       scheduling_method='alap',
+                       instruction_durations=[('h', None, 200), ('cx', [0, 1], 700),
+                                              ('measure', None, 1000)])
+        q = sc.qubits
+        self.assertEqual(sc.bit_start_time(q[0]), 300)
+        self.assertEqual(sc.bit_stop_time(q[0]), 2400)
+        self.assertEqual(sc.bit_start_time(q[1]), 500)
+        self.assertEqual(sc.bit_stop_time(q[1]), 2400)
+        self.assertEqual(sc.bit_start_time(q[2]), 1400)
+        self.assertEqual(sc.bit_stop_time(q[2]), 2400)
+        self.assertEqual(sc.bit_start_time(*q), 300)
+        self.assertEqual(sc.bit_stop_time(*q), 2400)
+        c = sc.clbits
+        self.assertEqual(sc.bit_start_time(c[0]), 1400)
+        self.assertEqual(sc.bit_stop_time(c[0]), 2400)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Change `Delay` to be able to accept `Clbit` argument as well as `Qubit` and stop broad casting of arguments.


### Details and comments
- Change `Delay's argument to `Bit`
- Change scheduling passes to add delays on clbits as well as qubits

Note: This change introduce `delay` instruction on clbits in qobj. Is it OK for backends? (They may need to omit delays on clbits.)

